### PR TITLE
Support for labels and MI ids on filters

### DIFF
--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteractionFields.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteractionFields.java
@@ -31,6 +31,7 @@ public class SearchInteractionFields {
     public static final String TAX_IDA = "taxIdA";
     public static final String TAX_IDB = "taxIdB";
     public static final String INTRA_TAX_ID = "intra_taxId";
+    public static final String TAX_ID_A_B = "taxIdA_B_ls";
     public static final String TYPE_A = "typeA";
     public static final String TYPE_B = "typeB";
     public static final String XREFS_A = "xrefsA";

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteractionFields.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteractionFields.java
@@ -110,6 +110,7 @@ public class SearchInteractionFields {
     public static final String TYPE_MI_A = "type_MI_A";
     public static final String TYPE_MI_B = "type_MI_B";
     public static final String TYPE_A_B_STR = "typeA_B_str";
+    public static final String TYPE_MI_A_B_STR = "type_MI_A_B_str";
     public static final String AFFECTED_BY_MUTATION = "affected_by_mutation";
     public static final String MUTATION_A = "mutation_A";
     public static final String MUTATION_B = "mutation_B";

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/utils/SearchInteractionUtility.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/utils/SearchInteractionUtility.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static uk.ac.ebi.intact.search.interactions.model.SearchInteractionFields.*;
 
@@ -164,6 +165,14 @@ public class SearchInteractionUtility {
         return filterQueries;
     }
 
+    private Criteria createCriteriaForLongValues(String tagForExcludingFacets, String field, Set<Long> values) {
+        Criteria conditions = null;
+        if (values != null && !values.isEmpty()) {
+            conditions = new Criteria(tagForExcludingFacets + field).in(values);
+        }
+        return conditions;
+    }
+
     private Criteria createCriteriaForStringValues(String tagForExcludingFacets, String field, Set<String> values) {
         Criteria conditions = null;
         if (values != null && !values.isEmpty()) {
@@ -200,7 +209,7 @@ public class SearchInteractionUtility {
     private void createBinaryInteractionIdsFilterCriteria(Set<Long> values, List<FilterQuery> filterQueries) {
         if (values != null && !values.isEmpty()) {
             String tagForExcludingFacets = "{!tag=GRAPH_FILTER}";
-            Criteria conditions = new Criteria(tagForExcludingFacets + BINARY_INTERACTION_ID).in(values);
+            Criteria conditions = createCriteriaForLongValues(tagForExcludingFacets, BINARY_INTERACTION_ID, values);
             filterQueries.add(new SimpleFilterQuery(conditions));
         }
     }
@@ -238,16 +247,16 @@ public class SearchInteractionUtility {
             if (species != null && !species.isEmpty()) {
                 // Return only interactions from exactly the same species in both interactors.
                 String tagForExcludingFacets = "{!tag=INTRA_SPECIES}";
-                Criteria conditions = createCriteriaForStringValues(tagForExcludingFacets, INTRA_SPECIES, species);
-                filterQueries.add(new SimpleFilterQuery(conditions));
+                createStringLabelsOrTaxIdsFilterCriteria(
+                        tagForExcludingFacets, species, INTRA_TAX_ID, INTRA_SPECIES, filterQueries);
             } else {
                 Criteria conditions = new Criteria("{!tag=INTRA_SPECIES}" + INTRA_TAX_ID).isNotNull();
                 filterQueries.add(new SimpleFilterQuery(conditions));
             }
-        } else {
+        } else if (species != null && !species.isEmpty()) {
             String tagForExcludingFacets = "{!tag=SPECIES}";
-            Criteria conditions = createCriteriaForStringValues(tagForExcludingFacets, SPECIES_A_B_STR, species);
-            filterQueries.add(new SimpleFilterQuery(conditions));
+            createStringLabelsOrTaxIdsFilterCriteria(
+                    tagForExcludingFacets, species, TAX_ID_A_B, SPECIES_A_B_STR, filterQueries);
         }
     }
 
@@ -269,8 +278,35 @@ public class SearchInteractionUtility {
     private void createInteractionHostOrganismsFilterCriteria(Set<String> interactionHostOrganismsFilter, List<FilterQuery> filterQueries) {
         if (interactionHostOrganismsFilter != null && !interactionHostOrganismsFilter.isEmpty()) {
             String tagForExcludingFacets = "{!tag=HOST_ORGANISM}";
-            Criteria conditions = createCriteriaForStringValues(tagForExcludingFacets, HOST_ORGANISM_S, interactionHostOrganismsFilter);
-            filterQueries.add(new SimpleFilterQuery(conditions));
+            createStringLabelsOrTaxIdsFilterCriteria(
+                    tagForExcludingFacets, interactionHostOrganismsFilter, HOST_ORGANISM_TAX_ID, HOST_ORGANISM_S, filterQueries);
+        }
+    }
+
+    private void createStringLabelsOrTaxIdsFilterCriteria(
+            String tagForExcludingFacets,
+            Set<String> values,
+            String taxIdField,
+            String labelField,
+            List<FilterQuery> filterQueries) {
+
+        if (values != null && !values.isEmpty()) {
+            Set<Long> taxIds = filterTaxIdsValues(values);
+            Set<String> labels = filterNotTaxIdsValues(values);
+
+            List<Criteria> conditions = new ArrayList<>();
+            if (!taxIds.isEmpty()) {
+                if (!labels.isEmpty()) {
+                    conditions.add(createCriteriaForLongValues(tagForExcludingFacets, taxIdField, taxIds));
+                    conditions.add(createCriteriaForStringValues(tagForExcludingFacets, labelField, labels));
+                } else {
+                    conditions.add(createCriteriaForLongValues(tagForExcludingFacets, taxIdField, taxIds));
+                }
+            } else if (!labels.isEmpty()) {
+                conditions.add(createCriteriaForStringValues(tagForExcludingFacets, labelField, labels));
+            }
+
+            conditions.forEach(condition -> filterQueries.add(new SimpleFilterQuery(condition)));
         }
     }
 
@@ -285,22 +321,19 @@ public class SearchInteractionUtility {
             Set<String> miIds = filterMiIdsValues(values);
             Set<String> labels = filterNotMiIdsValues(values);
 
-            Criteria conditions = null;
+            List<Criteria> conditions = new ArrayList<>();
             if (!miIds.isEmpty()) {
                 if (!labels.isEmpty()) {
-                    Criteria conditions1 = createCriteriaForStringValues(tagForExcludingFacets, miIdField, miIds);
-                    Criteria conditions2 = createCriteriaForStringValues(tagForExcludingFacets, labelField, labels);
-                    conditions = conditions1.or(conditions2);
+                    conditions.add(createCriteriaForStringValues(tagForExcludingFacets, miIdField, miIds));
+                    conditions.add(createCriteriaForStringValues(tagForExcludingFacets, labelField, labels));
                 } else {
-                    conditions = createCriteriaForStringValues(tagForExcludingFacets, miIdField, miIds);
+                    conditions.add(createCriteriaForStringValues(tagForExcludingFacets, miIdField, miIds));
                 }
             } else if (!labels.isEmpty()) {
-                conditions = createCriteriaForStringValues(tagForExcludingFacets, labelField, labels);
+                conditions.add(createCriteriaForStringValues(tagForExcludingFacets, labelField, labels));
             }
 
-            if (conditions != null) {
-                filterQueries.add(new SimpleFilterQuery(conditions));
-            }
+            conditions.forEach(condition -> filterQueries.add(new SimpleFilterQuery(condition)));
         }
     }
 
@@ -324,11 +357,39 @@ public class SearchInteractionUtility {
                 .collect(Collectors.toSet());
     }
 
+    private Set<Long> filterTaxIdsValues(Set<String> values) {
+        return values.stream()
+                .flatMap(this::splitTerm)
+                .filter(this::isTaxId)
+                .map(Long::parseLong)
+                .collect(Collectors.toSet());
+    }
+
+    private Set<String> filterNotTaxIdsValues(Set<String> values) {
+        return values.stream()
+                .flatMap(this::splitTerm)
+                .filter(value -> !isTaxId(value))
+                .map(s -> s.replace(" ", "\\ "))
+                .collect(Collectors.toSet());
+    }
+
     private boolean isMiId(String term) {
         String pattern = "MI:.*";
         Pattern r1 = Pattern.compile(pattern);
         Matcher m = r1.matcher(term);
 
         return m.matches();
+    }
+
+    private boolean isTaxId(String term) {
+        String pattern = "-?[0-9]+";
+        Pattern r1 = Pattern.compile(pattern);
+        Matcher m = r1.matcher(term);
+
+        return m.matches();
+    }
+
+    private Stream<String> splitTerm(String term) {
+        return Arrays.stream(term.split("__"));
     }
 }

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/utils/SearchInteractionUtility.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/utils/SearchInteractionUtility.java
@@ -369,7 +369,6 @@ public class SearchInteractionUtility {
         return values.stream()
                 .flatMap(this::splitTerm)
                 .filter(value -> !isTaxId(value))
-                .map(s -> s.replace(" ", "\\ "))
                 .collect(Collectors.toSet());
     }
 

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/utils/SearchInteractionUtility.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/utils/SearchInteractionUtility.java
@@ -23,6 +23,9 @@ import static uk.ac.ebi.intact.search.interactions.model.SearchInteractionFields
  */
 public class SearchInteractionUtility {
 
+    private static final Pattern MI_ID_PATTERN = Pattern.compile("MI:.*");
+    private static final Pattern TAX_ID_PATTERN = Pattern.compile("-?[0-9]+");
+
     //Custom version of ClientUtils.escapeQueryChars from solrJ
     public static String escapeQueryChars(String s) {
         StringBuilder sb = new StringBuilder();
@@ -323,16 +326,11 @@ public class SearchInteractionUtility {
 
             List<Criteria> conditions = new ArrayList<>();
             if (!miIds.isEmpty()) {
-                if (!labels.isEmpty()) {
-                    conditions.add(createCriteriaForStringValues(tagForExcludingFacets, miIdField, miIds));
-                    conditions.add(createCriteriaForStringValues(tagForExcludingFacets, labelField, labels));
-                } else {
-                    conditions.add(createCriteriaForStringValues(tagForExcludingFacets, miIdField, miIds));
-                }
-            } else if (!labels.isEmpty()) {
+                conditions.add(createCriteriaForStringValues(tagForExcludingFacets, miIdField, miIds));
+            }
+            if (!labels.isEmpty()) {
                 conditions.add(createCriteriaForStringValues(tagForExcludingFacets, labelField, labels));
             }
-
             conditions.forEach(condition -> filterQueries.add(new SimpleFilterQuery(condition)));
         }
     }
@@ -373,19 +371,11 @@ public class SearchInteractionUtility {
     }
 
     private boolean isMiId(String term) {
-        String pattern = "MI:.*";
-        Pattern r1 = Pattern.compile(pattern);
-        Matcher m = r1.matcher(term);
-
-        return m.matches();
+        return MI_ID_PATTERN.matcher(term).matches();
     }
 
     private boolean isTaxId(String term) {
-        String pattern = "-?[0-9]+";
-        Pattern r1 = Pattern.compile(pattern);
-        Matcher m = r1.matcher(term);
-
-        return m.matches();
+        return TAX_ID_PATTERN.matcher(term).matches();
     }
 
     private Stream<String> splitTerm(String term) {

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/utils/SearchInteractionUtility.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/utils/SearchInteractionUtility.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static uk.ac.ebi.intact.search.interactions.model.SearchInteractionFields.*;
 
@@ -54,46 +55,48 @@ public class SearchInteractionUtility {
 
         //We prepare the term to split by several characters
 
-        searchTerms = searchTerms.trim();
-        if (searchTerms != null && !searchTerms.isEmpty()) {
-            if (advancedSearch) {
-                userConditions= new SimpleStringCriteria(AdvancedSearchInteractionUtility.getAdvancedSearchQuery(searchTerms));
-            } else {
-                if (searchTerms.startsWith("\"") && searchTerms.endsWith("\"")) {
-                    words.add(searchTerms);
+        if (searchTerms != null) {
+            searchTerms = searchTerms.trim();
+            if (!searchTerms.isEmpty()) {
+                if (advancedSearch) {
+                    userConditions = new SimpleStringCriteria(AdvancedSearchInteractionUtility.getAdvancedSearchQuery(searchTerms));
                 } else {
-                    words = Arrays.asList(searchTerms.split("[\\s,\\n]"));
-                }
+                    if (searchTerms.startsWith("\"") && searchTerms.endsWith("\"")) {
+                        words.add(searchTerms);
+                    } else {
+                        words = Arrays.asList(searchTerms.split("[\\s,\\n]"));
+                    }
 
-                if (batchSearch) {
-                    userConditions = batchSearchConditions(words);
-                } else {
-                    //TODO Review query formation
-                    if (!searchTerms.trim().equals("*")) {
-                        for (String word : words) {
-                            word = word.trim();
-                            if (!word.isEmpty()) {
-                                if (word.equals("AND") || word.equals("OR") || word.equals("NOT")) {// solr treats these Capital words as logical words
-                                    word = lowerCaseWord(word);
-                                }
-                                if (userConditions == null) {
-                                    if (isEBIAc(word)) {
-                                        userConditions = new Criteria(AC_A_S).is(word)
-                                                .or(AC_B_S).is(word)
-                                                .or(AC_S).is(word);
-                                    } else {
-                                        word = escapeQueryChars(word);
-                                        userConditions = new Criteria(DEFAULT).expression(word);
+                    if (batchSearch) {
+                        userConditions = batchSearchConditions(words);
+                    } else {
+                        //TODO Review query formation
+                        if (!searchTerms.trim().equals("*")) {
+                            for (String word : words) {
+                                word = word.trim();
+                                if (!word.isEmpty()) {
+                                    if (word.equals("AND") || word.equals("OR") || word.equals("NOT")) {// solr treats these Capital words as logical words
+                                        word = lowerCaseWord(word);
                                     }
-                                } else {
-                                    if (isEBIAc(word)) {
-                                        Criteria criteria = new Criteria(AC_A_S).is(word)
-                                                .or(AC_B_S).is(word)
-                                                .or(AC_S).is(word);
-                                        userConditions.or(criteria);
+                                    if (userConditions == null) {
+                                        if (isEBIAc(word)) {
+                                            userConditions = new Criteria(AC_A_S).is(word)
+                                                    .or(AC_B_S).is(word)
+                                                    .or(AC_S).is(word);
+                                        } else {
+                                            word = escapeQueryChars(word);
+                                            userConditions = new Criteria(DEFAULT).expression(word);
+                                        }
                                     } else {
-                                        word = escapeQueryChars(word);
-                                        userConditions = userConditions.or(DEFAULT).expression(word);
+                                        if (isEBIAc(word)) {
+                                            Criteria criteria = new Criteria(AC_A_S).is(word)
+                                                    .or(AC_B_S).is(word)
+                                                    .or(AC_S).is(word);
+                                            userConditions.or(criteria);
+                                        } else {
+                                            word = escapeQueryChars(word);
+                                            userConditions = userConditions.or(DEFAULT).expression(word);
+                                        }
                                     }
                                 }
                             }
@@ -129,94 +132,100 @@ public class SearchInteractionUtility {
         createInteractorSpeciesFilterCriteria(parameters.getInteractorSpeciesFilter(), parameters.isIntraSpeciesFilter(), filterQueries);
 
         //Interactor type filter
-        createInteractorTypeFilterCriteria("{!tag=TYPE}", parameters.getInteractorTypesFilter(), filterQueries);
+        createInteractorTypeFilterCriteria(parameters.getInteractorTypesFilter(), filterQueries);
 
         //Interaction detection method filter
-        createFilterCriteriaForStringValues("{!tag=DETECTION_METHOD}", parameters.getInteractionDetectionMethodsFilter(), DETECTION_METHOD_S, filterQueries);
+        createInteractionDetectionMethodsFilterCriteria(parameters.getInteractionDetectionMethodsFilter(), filterQueries);
 
         //Interaction type filter
-        createFilterCriteriaForStringValues("{!tag=INTERACTION_TYPE}", parameters.getInteractionTypesFilter(), TYPE_S, filterQueries);
+        createInteractionTypeFilterCriteria(parameters.getInteractionTypesFilter(), filterQueries);
 
         //Interaction host organism filter
-        createFilterCriteriaForStringValues("{!tag=HOST_ORGANISM}", parameters.getInteractionHostOrganismsFilter(), HOST_ORGANISM_S, filterQueries);
+        createInteractionHostOrganismsFilterCriteria(parameters.getInteractionHostOrganismsFilter(), filterQueries);
 
         //Negative filter
-        createNegativeInteractionsFilterCriteria("{!tag=NEGATIVE_INTERACTION}", parameters.getNegativeFilter().booleanValue, NEGATIVE, filterQueries);
+        createNegativeInteractionsFilterCriteria(parameters.getNegativeFilter().booleanValue, filterQueries);
 
         //Mutation filter
         createFilterCriteriaForBoolean("{!tag=MUTATION}", parameters.isMutationFilter(), AFFECTED_BY_MUTATION, filterQueries);
 
         //Expansion filter
-        createExpansionFilterCriteria("{!tag=EXPANSION}", parameters.isExpansionFilter(), filterQueries);
+        createExpansionFilterCriteria(parameters.isExpansionFilter(), filterQueries);
 
         //MIScore filter
-        createMIScoreFilterCriteria("{!tag=MI_SCORE}", parameters.getMinMIScore(), parameters.getMaxMIScore(), filterQueries);
+        createMIScoreFilterCriteria(parameters.getMinMIScore(), parameters.getMaxMIScore(), filterQueries);
 
         //binaryInteractionIds filter
-        createFilterCriteriaForLongValues("{!tag=GRAPH_FILTER}", parameters.getBinaryInteractionIds(), BINARY_INTERACTION_ID, filterQueries);
+        createBinaryInteractionIdsFilterCriteria(parameters.getBinaryInteractionIds(), filterQueries);
 
         //InteractorAcs filter
-        createInteractorAcsFilter("{!tag=GRAPH_FILTER}", parameters.getInteractorAcs(), filterQueries);
+        createInteractorAcsFilter(parameters.getInteractorAcs(), filterQueries);
 
         return filterQueries;
     }
 
-    private void createFilterCriteriaForStringValues(String tagForExcludingFacets, Set<String> values, String field, List<FilterQuery> filterQueries) {
-
+    private Criteria createCriteriaForStringValues(String tagForExcludingFacets, String field, Set<String> values) {
+        Criteria conditions = null;
         if (values != null && !values.isEmpty()) {
-            Criteria conditions = new Criteria(tagForExcludingFacets + field).in(values);
-            conditions.isOr();
-            filterQueries.add(new SimpleFilterQuery(conditions));
-
+            conditions = new Criteria(tagForExcludingFacets + field).in(values);
         }
+        return conditions;
     }
 
-    private void createFilterCriteriaForLongValues(String tagForExcludingFacets, Set<Long> values, String field, List<FilterQuery> filterQueries) {
-
+    private void createInteractorAcsFilter(Set<String> values, List<FilterQuery> filterQueries) {
         if (values != null && !values.isEmpty()) {
-            Criteria conditions = new Criteria(tagForExcludingFacets + field).in(values);
-            conditions.isOr();
-            filterQueries.add(new SimpleFilterQuery(conditions));
-        }
-    }
-
-    private void createInteractorAcsFilter(String tagForExcludingFacets, Set<String> values, List<FilterQuery> filterQueries) {
-        if (values != null && !values.isEmpty()) {
+            String tagForExcludingFacets = "{!tag=GRAPH_FILTER}";
             Criteria conditions = new Criteria(tagForExcludingFacets + AC_A_S).in(values)
                     .or(AC_B_S).in(values);
             filterQueries.add(new SimpleFilterQuery(conditions));
-
         }
     }
 
     private void createFilterCriteriaForBoolean(String tagForExcludingFacets, boolean value, String field, List<FilterQuery> filterQueries) {
-
         if (value) {
             Criteria conditions = new Criteria(tagForExcludingFacets + field).is(value);
             filterQueries.add(new SimpleFilterQuery(conditions));
         }
     }
 
-    private void createNegativeInteractionsFilterCriteria(String tagForExcludingFacets, Boolean value, String field, List<FilterQuery> filterQueries) {
-
-        if (value != null) {
-            Criteria conditions = new Criteria(tagForExcludingFacets + field).is(value);
+    private void createInteractionDetectionMethodsFilterCriteria(Set<String> values, List<FilterQuery> filterQueries) {
+        if (values != null && !values.isEmpty()) {
+            // TODO: add search for MI ids for detection method when new field is added in SOLR
+            String tagForExcludingFacets = "{!tag=DETECTION_METHOD}";
+            Criteria conditions = createCriteriaForStringValues(tagForExcludingFacets, DETECTION_METHOD_S, values);
             filterQueries.add(new SimpleFilterQuery(conditions));
         }
     }
 
-    private void createExpansionFilterCriteria(String tagForExcludingFacets, boolean value, List<FilterQuery> filterQueries) {
+    private void createBinaryInteractionIdsFilterCriteria(Set<Long> values, List<FilterQuery> filterQueries) {
+        if (values != null && !values.isEmpty()) {
+            String tagForExcludingFacets = "{!tag=GRAPH_FILTER}";
+            Criteria conditions = new Criteria(tagForExcludingFacets + BINARY_INTERACTION_ID).in(values);
+            filterQueries.add(new SimpleFilterQuery(conditions));
+        }
+    }
+
+    private void createNegativeInteractionsFilterCriteria(Boolean value, List<FilterQuery> filterQueries) {
+        if (value != null) {
+            String tagForExcludingFacets = "{!tag=NEGATIVE_INTERACTION}";
+            createFilterCriteriaForBoolean(tagForExcludingFacets, value, NEGATIVE, filterQueries);
+        }
+    }
+
+    private void createExpansionFilterCriteria(boolean value, List<FilterQuery> filterQueries) {
         // Expansion filter meaning:
         // true: hides spoke expanded interactions
         // false: keeps every interaction
         if (value) {
+            String tagForExcludingFacets = "{!tag=EXPANSION}";
             Criteria conditions = new Criteria(tagForExcludingFacets + "-" + EXPANSION_METHOD).is("spoke expansion");
             filterQueries.add(new SimpleFilterQuery(conditions));
         }
     }
 
 
-    private void createMIScoreFilterCriteria(String tagForExcludingFacets, double minScore, double maxScore, List<FilterQuery> filterQueries) {
+    private void createMIScoreFilterCriteria(double minScore, double maxScore, List<FilterQuery> filterQueries) {
+        String tagForExcludingFacets = "{!tag=MI_SCORE}";
         Criteria conditions = new Criteria(tagForExcludingFacets + INTACT_MISCORE).between(minScore, maxScore);
         filterQueries.add(new SimpleFilterQuery(conditions));
     }
@@ -225,40 +234,98 @@ public class SearchInteractionUtility {
     //               if true it creates 'or' condition between set of species
     // Adds tags in solr to allow calculate properly the facets for multiselection in species and interactor type
     private void createInteractorSpeciesFilterCriteria(Set<String> species, boolean intraSpeciesFilter, List<FilterQuery> filterQueries) {
-        Criteria conditions = null;
-
-        if (species != null && !species.isEmpty()) {
-            if (!intraSpeciesFilter) {
-                conditions = new Criteria("{!tag=SPECIES}" + SPECIES_A_B_STR).in(species);
-                conditions.isOr();
-            } else { // Return only interactions from exactly the same species in both interactors.
-                conditions = new Criteria("{!tag=INTRA_SPECIES}" + INTRA_SPECIES).in(species);
+        if (intraSpeciesFilter) {
+            if (species != null && !species.isEmpty()) {
+                // Return only interactions from exactly the same species in both interactors.
+                String tagForExcludingFacets = "{!tag=INTRA_SPECIES}";
+                Criteria conditions = createCriteriaForStringValues(tagForExcludingFacets, INTRA_SPECIES, species);
+                filterQueries.add(new SimpleFilterQuery(conditions));
+            } else {
+                Criteria conditions = new Criteria("{!tag=INTRA_SPECIES}" + INTRA_TAX_ID).isNotNull();
+                filterQueries.add(new SimpleFilterQuery(conditions));
             }
         } else {
-            if (intraSpeciesFilter) {
-                conditions = new Criteria("{!tag=INTRA_SPECIES}" + INTRA_SPECIES).isNotNull();
-            }
-        }
-        if (conditions != null) {
+            String tagForExcludingFacets = "{!tag=SPECIES}";
+            Criteria conditions = createCriteriaForStringValues(tagForExcludingFacets, SPECIES_A_B_STR, species);
             filterQueries.add(new SimpleFilterQuery(conditions));
         }
     }
 
     // Adds tags in solr to allow calculate properly the facets for multiselection in species and interactor type
-    private void createInteractorTypeFilterCriteria(String tagForExcludingFacets, Set<String> interactorTypesFilter, List<FilterQuery> filterQueries) {
+    private void createInteractorTypeFilterCriteria(Set<String> interactorTypesFilter, List<FilterQuery> filterQueries) {
+        String tagForExcludingFacets = "{!tag=TYPE}";
+        createStringLabelsOrMiIdsFilterCriteria(tagForExcludingFacets, interactorTypesFilter, TYPE_MI_A_B_STR, TYPE_A_B_STR, filterQueries);
+    }
 
-        if (interactorTypesFilter != null && !interactorTypesFilter.isEmpty()) {
-            Criteria conditions = null;
-
-            conditions = new Criteria(tagForExcludingFacets + TYPE_A_B_STR).in(interactorTypesFilter);
-            conditions.isOr();
-
+    private void createInteractionTypeFilterCriteria(Set<String> interactionTypesFilter, List<FilterQuery> filterQueries) {
+        if (interactionTypesFilter != null && !interactionTypesFilter.isEmpty()) {
+            // TODO: add search for MI ids for interaction type when new field is added in SOLR
+            String tagForExcludingFacets = "{!tag=INTERACTION_TYPE}";
+            Criteria conditions = createCriteriaForStringValues(tagForExcludingFacets, TYPE_S, interactionTypesFilter);
             filterQueries.add(new SimpleFilterQuery(conditions));
+        }
+    }
+
+    private void createInteractionHostOrganismsFilterCriteria(Set<String> interactionHostOrganismsFilter, List<FilterQuery> filterQueries) {
+        if (interactionHostOrganismsFilter != null && !interactionHostOrganismsFilter.isEmpty()) {
+            String tagForExcludingFacets = "{!tag=HOST_ORGANISM}";
+            Criteria conditions = createCriteriaForStringValues(tagForExcludingFacets, HOST_ORGANISM_S, interactionHostOrganismsFilter);
+            filterQueries.add(new SimpleFilterQuery(conditions));
+        }
+    }
+
+    private void createStringLabelsOrMiIdsFilterCriteria(
+            String tagForExcludingFacets,
+            Set<String> values,
+            String miIdField,
+            String labelField,
+            List<FilterQuery> filterQueries) {
+
+        if (values != null && !values.isEmpty()) {
+            Set<String> miIds = filterMiIdsValues(values);
+            Set<String> labels = filterNotMiIdsValues(values);
+
+            Criteria conditions = null;
+            if (!miIds.isEmpty()) {
+                if (!labels.isEmpty()) {
+                    Criteria conditions1 = createCriteriaForStringValues(tagForExcludingFacets, miIdField, miIds);
+                    Criteria conditions2 = createCriteriaForStringValues(tagForExcludingFacets, labelField, labels);
+                    conditions = conditions1.or(conditions2);
+                } else {
+                    conditions = createCriteriaForStringValues(tagForExcludingFacets, miIdField, miIds);
+                }
+            } else if (!labels.isEmpty()) {
+                conditions = createCriteriaForStringValues(tagForExcludingFacets, labelField, labels);
+            }
+
+            if (conditions != null) {
+                filterQueries.add(new SimpleFilterQuery(conditions));
+            }
         }
     }
 
     private boolean isEBIAc(String term) {
         String pattern = "EBI-" + "[0-9]+";
+        Pattern r1 = Pattern.compile(pattern);
+        Matcher m = r1.matcher(term);
+
+        return m.matches();
+    }
+
+    private Set<String> filterMiIdsValues(Set<String> values) {
+        return values.stream()
+                .filter(this::isMiId)
+                .collect(Collectors.toSet());
+    }
+
+    private Set<String> filterNotMiIdsValues(Set<String> values) {
+        return values.stream()
+                .filter(value -> !isMiId(value))
+                .collect(Collectors.toSet());
+    }
+
+    private boolean isMiId(String term) {
+        String pattern = "MI:.*";
         Pattern r1 = Pattern.compile(pattern);
         Matcher m = r1.matcher(term);
 


### PR DESCRIPTION
Update filters to support using labels or MI ids. This does not work yet for all filters as some (detection method and interaction type) are not properly indexed by MI ids in SOLR, but it works for the rest. I will update the SOLR schema and indexing so in the next release these fields are also indexed properly, and then we can update to support those filters too.