### PR TITLE
New solr fields

### DIFF
--- a/intact-search-interactions-service/pom.xml
+++ b/intact-search-interactions-service/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.search.interactions</groupId>
         <artifactId>intact-search-interactions-module</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteraction.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteraction.java
@@ -319,10 +319,10 @@ public class SearchInteraction extends AdvancedSearchInteraction {
     private String detectionMethodMIIdentifierStyled;
 
     @Field(IDENTIFICATION_METHOD_MI_A_STYLED)
-    private String identificationMethodMIAStyled;
+    private Set<String> identificationMethodMIAStyled;
 
     @Field(IDENTIFICATION_METHOD_MI_B_STYLED)
-    private String identificationMethodMIBStyled;
+    private Set<String> identificationMethodMIBStyled;
 
     @Field(TYPE_MI_A_STYLED)
     private String typeMIAStyled;
@@ -1219,19 +1219,19 @@ public class SearchInteraction extends AdvancedSearchInteraction {
         this.detectionMethodMIIdentifierStyled = detectionMethodMIIdentifierStyled;
     }
 
-    public String getIdentificationMethodMIAStyled() {
+    public Set<String> getIdentificationMethodMIAStyled() {
         return identificationMethodMIAStyled;
     }
 
-    public void setIdentificationMethodMIAStyled(String identificationMethodMIAStyled) {
+    public void setIdentificationMethodMIAStyled(Set<String> identificationMethodMIAStyled) {
         this.identificationMethodMIAStyled = identificationMethodMIAStyled;
     }
 
-    public String getIdentificationMethodMIBStyled() {
+    public Set<String> getIdentificationMethodMIBStyled() {
         return identificationMethodMIBStyled;
     }
 
-    public void setIdentificationMethodMIBStyled(String identificationMethodMIBStyled) {
+    public void setIdentificationMethodMIBStyled(Set<String> identificationMethodMIBStyled) {
         this.identificationMethodMIBStyled = identificationMethodMIBStyled;
     }
 

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteraction.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteraction.java
@@ -315,6 +315,15 @@ public class SearchInteraction extends AdvancedSearchInteraction {
     @Field(TYPE_MI_IDENTIFIER_STYLED)
     private String typeMIIdentifierStyled;
 
+    @Field(DETECTION_METHOD_MI_STYLED)
+    private String detectionMethodMIIdentifierStyled;
+
+    @Field(IDENTIFICATION_METHOD_MI_A_STYLED)
+    private String identificationMethodMIAStyled;
+
+    @Field(IDENTIFICATION_METHOD_MI_B_STYLED)
+    private String identificationMethodMIBStyled;
+
     @Field(TYPE_MI_A_STYLED)
     private String typeMIAStyled;
 
@@ -1200,6 +1209,30 @@ public class SearchInteraction extends AdvancedSearchInteraction {
 
     public void setTypeMIIdentifierStyled(String typeMIIdentifierStyled) {
         this.typeMIIdentifierStyled = typeMIIdentifierStyled;
+    }
+
+    public String getDetectionMethodMIIdentifierStyled() {
+        return detectionMethodMIIdentifierStyled;
+    }
+
+    public void setDetectionMethodMIIdentifierStyled(String detectionMethodMIIdentifierStyled) {
+        this.detectionMethodMIIdentifierStyled = detectionMethodMIIdentifierStyled;
+    }
+
+    public String getIdentificationMethodMIAStyled() {
+        return identificationMethodMIAStyled;
+    }
+
+    public void setIdentificationMethodMIAStyled(String identificationMethodMIAStyled) {
+        this.identificationMethodMIAStyled = identificationMethodMIAStyled;
+    }
+
+    public String getIdentificationMethodMIBStyled() {
+        return identificationMethodMIBStyled;
+    }
+
+    public void setIdentificationMethodMIBStyled(String identificationMethodMIBStyled) {
+        this.identificationMethodMIBStyled = identificationMethodMIBStyled;
     }
 
     public String getTypeMIAStyled() {

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteractionFields.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteractionFields.java
@@ -151,8 +151,6 @@ public class SearchInteractionFields {
     // Participant detection method
     public static final String IDENTIFICATION_METHOD_MI_A_STYLED = "identification_method_mi_A_styled";
     public static final String IDENTIFICATION_METHOD_MI_B_STYLED = "identification_method_mi_B_styled";
-    // CopyField
-    public static final String IDENTIFICATION_METHOD_MI_A_B_STYLED = "detection_method_mi_styled";
 
     // Interactor type
     public static final String TYPE_MI_A_STYLED = "type_MI_A_styled";

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteractionFields.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteractionFields.java
@@ -72,11 +72,14 @@ public class SearchInteractionFields {
     public static final String IDENTIFICATION_METHODS_B = "identification_method_B";
     public static final String IDENTIFICATION_METHOD_MI_IDENTIFIERS_A = "identification_method_mi_identifier_A";
     public static final String IDENTIFICATION_METHOD_MI_IDENTIFIERS_B = "identification_method_mi_identifier_B";
+    public static final String IDENTIFICATION_METHODS_A_B_S = "identification_method_A_B_str";
+    public static final String IDENTIFICATION_METHODS_MI_IDS_A_B_S = "identification_method_mi_identifier_A_B_str";
 
     public static final String DETECTION_METHOD = "detection_method";
     // CopyField for faceting
     public static final String DETECTION_METHOD_S = "detection_method_s";
     public static final String DETECTION_METHOD_MI_IDENTIFIER = "detection_method_mi_identifier";
+    public static final String DETECTION_METHOD_MI_IDENTIFIER_S = "detection_method_mi_identifier_s";
     public static final String PUBLICATION_AUTHORS = "publication_authors";
     public static final String FIRST_AUTHOR = "first_author";
     public static final String PUBLICATION_IDENTIFIERS = "publication_identifiers";
@@ -100,6 +103,7 @@ public class SearchInteractionFields {
     public static final String NEGATIVE = "negative";
     public static final String TYPE = "type";
     public static final String TYPE_MI_IDENTIFIER = "type_mi_identifier";
+    public static final String TYPE_MI_IDENTIFIER_S = "type_mi_identifier_s";
     public static final String TYPE_S = "type_s";
     public static final String HOST_ORGANISM = "host_organism";
     public static final String HOST_ORGANISM_TAX_ID = "host_organism_taxId";
@@ -140,6 +144,15 @@ public class SearchInteractionFields {
 
     // Interaction type
     public static final String TYPE_MI_IDENTIFIER_STYLED = "type_mi_identifier_styled";
+
+    // Interaction detection method
+    public static final String DETECTION_METHOD_MI_STYLED = "detection_method_styled";
+
+    // Participant detection method
+    public static final String IDENTIFICATION_METHOD_MI_A_STYLED = "identification_method_mi_A_styled";
+    public static final String IDENTIFICATION_METHOD_MI_B_STYLED = "identification_method_mi_B_styled";
+    // CopyField
+    public static final String IDENTIFICATION_METHOD_MI_A_B_STYLED = "detection_method_mi_styled";
 
     // Interactor type
     public static final String TYPE_MI_A_STYLED = "type_MI_A_styled";

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteractionFields.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/SearchInteractionFields.java
@@ -146,11 +146,12 @@ public class SearchInteractionFields {
     public static final String TYPE_MI_IDENTIFIER_STYLED = "type_mi_identifier_styled";
 
     // Interaction detection method
-    public static final String DETECTION_METHOD_MI_STYLED = "detection_method_styled";
+    public static final String DETECTION_METHOD_MI_STYLED = "detection_method_mi_styled";
 
     // Participant detection method
     public static final String IDENTIFICATION_METHOD_MI_A_STYLED = "identification_method_mi_A_styled";
     public static final String IDENTIFICATION_METHOD_MI_B_STYLED = "identification_method_mi_B_styled";
+    public static final String IDENTIFICATION_METHOD_MI_A_B_STYLED = "identification_method_mi_A_B_styled";
 
     // Interactor type
     public static final String TYPE_MI_A_STYLED = "type_MI_A_styled";

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/parameters/InteractionGraphJSONParameters.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/parameters/InteractionGraphJSONParameters.java
@@ -32,6 +32,8 @@ public class InteractionGraphJSONParameters implements SimpleSearchParametersI {
     protected Set<String> interactorTypesFilter;
     @Schema(description = "Filters interactions based on interaction detection method", example = "[]")
     protected Set<String> interactionDetectionMethodsFilter;
+    @Schema(description = "Filters interactions based on participant detection method", example = "[]")
+    protected Set<String> participantDetectionMethodsFilter;
     @Schema(description = "Filters interactions based on interaction types", example = "[]")
     protected Set<String> interactionTypesFilter;
     @Schema(description = "Filters interactions based on interaction host organism", example = "[]")

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/parameters/InteractionSearchParameters.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/parameters/InteractionSearchParameters.java
@@ -26,6 +26,7 @@ public class InteractionSearchParameters extends InteractionGraphJSONParameters 
                 .advancedSearch(parameters.isAdvancedSearch())
 
                 .interactionDetectionMethodsFilter(parameters.getInteractionDetectionMethodsFilter())
+                .participantDetectionMethodsFilter(parameters.getParticipantDetectionMethodsFilter())
                 .interactionTypesFilter(parameters.getInteractionTypesFilter())
                 .interactionHostOrganismsFilter(parameters.getInteractionHostOrganismsFilter())
                 .interactorTypesFilter(parameters.getInteractorTypesFilter())

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/parameters/PagedFormattedInteractionSearchParameters.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/parameters/PagedFormattedInteractionSearchParameters.java
@@ -21,6 +21,7 @@ public class PagedFormattedInteractionSearchParameters extends PagedInteractionS
                 .advancedSearch(parameters.isAdvancedSearch())
 
                 .interactionDetectionMethodsFilter(parameters.getInteractionDetectionMethodsFilter())
+                .participantDetectionMethodsFilter(parameters.getParticipantDetectionMethodsFilter())
                 .interactionTypesFilter(parameters.getInteractionTypesFilter())
                 .interactionHostOrganismsFilter(parameters.getInteractionHostOrganismsFilter())
                 .interactorTypesFilter(parameters.getInteractorTypesFilter())

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/parameters/PagedInteractionGraphJSONParameters.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/parameters/PagedInteractionGraphJSONParameters.java
@@ -36,6 +36,7 @@ public class PagedInteractionGraphJSONParameters extends InteractionGraphJSONPar
                 .interactorSpeciesFilter(interactorSpeciesFilter)
                 .interactorTypesFilter(interactorTypesFilter)
                 .interactionDetectionMethodsFilter(interactionDetectionMethodsFilter)
+                .participantDetectionMethodsFilter(participantDetectionMethodsFilter)
                 .interactionTypesFilter(interactionTypesFilter)
                 .interactionHostOrganismsFilter(interactionHostOrganismsFilter)
 

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/parameters/PagedInteractionSearchParameters.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/model/parameters/PagedInteractionSearchParameters.java
@@ -36,6 +36,7 @@ public class PagedInteractionSearchParameters extends InteractionSearchParameter
                 .advancedSearch(parameters.isAdvancedSearch())
 
                 .interactionDetectionMethodsFilter(parameters.getInteractionDetectionMethodsFilter())
+                .participantDetectionMethodsFilter(parameters.getParticipantDetectionMethodsFilter())
                 .interactionTypesFilter(parameters.getInteractionTypesFilter())
                 .interactionHostOrganismsFilter(parameters.getInteractionHostOrganismsFilter())
                 .interactorTypesFilter(parameters.getInteractorTypesFilter())

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/repository/CustomizedInteractionRepositoryImpl.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/repository/CustomizedInteractionRepositoryImpl.java
@@ -107,6 +107,7 @@ public class CustomizedInteractionRepositoryImpl implements CustomizedInteractio
                 "{!ex=SPECIES,INTRA_SPECIES,GRAPH_FILTER}" + TAX_ID_A_B_STYLED,
                 "{!ex=SPECIES,INTRA_SPECIES,GRAPH_FILTER}" + INTRA_TAX_ID_STYLED,
                 "{!ex=TYPE,GRAPH_FILTER}" + TYPE_MI_A_B_STYLED,
+                "{!ex=DETECTION_METHOD,GRAPH_FILTER}" + DETECTION_METHOD_S,
                 "{!ex=DETECTION_METHOD,GRAPH_FILTER}" + DETECTION_METHOD_MI_STYLED,
                 "{!ex=INTERACTION_TYPE,GRAPH_FILTER}" + TYPE_MI_IDENTIFIER_STYLED,
                 "{!ex=HOST_ORGANISM,GRAPH_FILTER}" + HOST_ORGANISM_TAXID_STYLED,

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/repository/CustomizedInteractionRepositoryImpl.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/repository/CustomizedInteractionRepositoryImpl.java
@@ -109,6 +109,7 @@ public class CustomizedInteractionRepositoryImpl implements CustomizedInteractio
                 "{!ex=TYPE,GRAPH_FILTER}" + TYPE_MI_A_B_STYLED,
                 "{!ex=DETECTION_METHOD,GRAPH_FILTER}" + DETECTION_METHOD_S,
                 "{!ex=DETECTION_METHOD,GRAPH_FILTER}" + DETECTION_METHOD_MI_STYLED,
+                "{!ex=PARTICIPANT_DETECTION_METHOD,GRAPH_FILTER}" + IDENTIFICATION_METHOD_MI_A_B_STYLED,
                 "{!ex=INTERACTION_TYPE,GRAPH_FILTER}" + TYPE_MI_IDENTIFIER_STYLED,
                 "{!ex=HOST_ORGANISM,GRAPH_FILTER}" + HOST_ORGANISM_TAXID_STYLED,
                 "{!ex=NEGATIVE_INTERACTION,GRAPH_FILTER}" + NEGATIVE,

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/repository/CustomizedInteractionRepositoryImpl.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/repository/CustomizedInteractionRepositoryImpl.java
@@ -107,7 +107,7 @@ public class CustomizedInteractionRepositoryImpl implements CustomizedInteractio
                 "{!ex=SPECIES,INTRA_SPECIES,GRAPH_FILTER}" + TAX_ID_A_B_STYLED,
                 "{!ex=SPECIES,INTRA_SPECIES,GRAPH_FILTER}" + INTRA_TAX_ID_STYLED,
                 "{!ex=TYPE,GRAPH_FILTER}" + TYPE_MI_A_B_STYLED,
-                "{!ex=DETECTION_METHOD,GRAPH_FILTER}" + DETECTION_METHOD_S,
+                "{!ex=DETECTION_METHOD,GRAPH_FILTER}" + DETECTION_METHOD_MI_STYLED,
                 "{!ex=INTERACTION_TYPE,GRAPH_FILTER}" + TYPE_MI_IDENTIFIER_STYLED,
                 "{!ex=HOST_ORGANISM,GRAPH_FILTER}" + HOST_ORGANISM_TAXID_STYLED,
                 "{!ex=NEGATIVE_INTERACTION,GRAPH_FILTER}" + NEGATIVE,

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/utils/SearchInteractionUtility.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/utils/SearchInteractionUtility.java
@@ -198,12 +198,8 @@ public class SearchInteractionUtility {
     }
 
     private void createInteractionDetectionMethodsFilterCriteria(Set<String> values, List<FilterQuery> filterQueries) {
-        if (values != null && !values.isEmpty()) {
-            // TODO: add search for MI ids for detection method when new field is added in SOLR
-            String tagForExcludingFacets = "{!tag=DETECTION_METHOD}";
-            Criteria conditions = createCriteriaForStringValues(tagForExcludingFacets, DETECTION_METHOD_S, values);
-            filterQueries.add(new SimpleFilterQuery(conditions));
-        }
+        String tagForExcludingFacets = "{!tag=DETECTION_METHOD}";
+        createStringLabelsOrMiIdsFilterCriteria(tagForExcludingFacets, values, DETECTION_METHOD_MI_IDENTIFIER_S, DETECTION_METHOD_S, filterQueries);
     }
 
     private void createBinaryInteractionIdsFilterCriteria(Set<Long> values, List<FilterQuery> filterQueries) {
@@ -267,12 +263,8 @@ public class SearchInteractionUtility {
     }
 
     private void createInteractionTypeFilterCriteria(Set<String> interactionTypesFilter, List<FilterQuery> filterQueries) {
-        if (interactionTypesFilter != null && !interactionTypesFilter.isEmpty()) {
-            // TODO: add search for MI ids for interaction type when new field is added in SOLR
-            String tagForExcludingFacets = "{!tag=INTERACTION_TYPE}";
-            Criteria conditions = createCriteriaForStringValues(tagForExcludingFacets, TYPE_S, interactionTypesFilter);
-            filterQueries.add(new SimpleFilterQuery(conditions));
-        }
+        String tagForExcludingFacets = "{!tag=INTERACTION_TYPE}";
+        createStringLabelsOrMiIdsFilterCriteria(tagForExcludingFacets, interactionTypesFilter, TYPE_MI_IDENTIFIER_S, TYPE_S, filterQueries);
     }
 
     private void createInteractionHostOrganismsFilterCriteria(Set<String> interactionHostOrganismsFilter, List<FilterQuery> filterQueries) {

--- a/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/utils/SearchInteractionUtility.java
+++ b/intact-search-interactions-service/src/main/java/uk/ac/ebi/intact/search/interactions/utils/SearchInteractionUtility.java
@@ -138,6 +138,9 @@ public class SearchInteractionUtility {
         //Interaction detection method filter
         createInteractionDetectionMethodsFilterCriteria(parameters.getInteractionDetectionMethodsFilter(), filterQueries);
 
+        //Participant detection method filter
+        createParticipantDetectionMethodsFilterCriteria(parameters.getParticipantDetectionMethodsFilter(), filterQueries);
+
         //Interaction type filter
         createInteractionTypeFilterCriteria(parameters.getInteractionTypesFilter(), filterQueries);
 
@@ -200,6 +203,11 @@ public class SearchInteractionUtility {
     private void createInteractionDetectionMethodsFilterCriteria(Set<String> values, List<FilterQuery> filterQueries) {
         String tagForExcludingFacets = "{!tag=DETECTION_METHOD}";
         createStringLabelsOrMiIdsFilterCriteria(tagForExcludingFacets, values, DETECTION_METHOD_MI_IDENTIFIER_S, DETECTION_METHOD_S, filterQueries);
+    }
+
+    private void createParticipantDetectionMethodsFilterCriteria(Set<String> values, List<FilterQuery> filterQueries) {
+        String tagForExcludingFacets = "{!tag=PARTICIPANT_DETECTION_METHOD}";
+        createStringLabelsOrMiIdsFilterCriteria(tagForExcludingFacets, values, IDENTIFICATION_METHODS_MI_IDS_A_B_S, IDENTIFICATION_METHODS_A_B_S, filterQueries);
     }
 
     private void createBinaryInteractionIdsFilterCriteria(Set<Long> values, List<FilterQuery> filterQueries) {

--- a/intact-search-interactions-service/src/test/java/uk/ac/ebi/intact/search/interactions/service/ChildInteractorSearchServiceTest.java
+++ b/intact-search-interactions-service/src/test/java/uk/ac/ebi/intact/search/interactions/service/ChildInteractorSearchServiceTest.java
@@ -123,6 +123,35 @@ public class ChildInteractorSearchServiceTest {
         }
     }
 
+    @Test
+    public void getUniqueChildInteractorsFromInteractionFilterQueryWithIdentifiers() {
+        PagedInteractionSearchParameters params = PagedInteractionSearchParameters.builder()
+                .query("physical association")
+                .interactorSpeciesFilter(Set.of("Homo sapiens__9606"))
+                .interactorTypesFilter(Set.of("MI:0326"))
+                .interactionDetectionMethodsFilter(Set.of("MI:0071"))
+                .interactionTypesFilter(Set.of("MI:0915"))
+                .interactionHostOrganismsFilter(Set.of("In vitro__-1"))
+                .minMIScore(0)
+                .maxMIScore(0.7)
+                .build();
+        GroupPage<SearchChildInteractor> childInteractorsOp = childInteractorSearchService.findInteractorsWithGroup(
+                params);
+        assertEquals(2, childInteractorsOp.getTotalElements()); //Total documents found before grouping
+        assertEquals(2, childInteractorsOp.getNumberOfElements()); //Elements in the page
+
+        long numInteractors = childInteractorSearchService.countInteractorsWithGroup(params);
+        assertEquals(2, numInteractors);
+
+        List<String> interactorAcs = List.of("EBI-724102", "EBI-715849");
+
+        for (SearchChildInteractor searchChildInteractor : childInteractorsOp.getContent()) {
+            if (!interactorAcs.contains(searchChildInteractor.getInteractorAc())) {
+                Assert.fail("The interactor is not in the list of interactors expected");
+            }
+        }
+    }
+
     /**
      * Expected sync between interactions and child interactors
      */
@@ -297,6 +326,98 @@ public class ChildInteractorSearchServiceTest {
         for (SearchChildInteractor interactor : interactorOp.getContent()) {
             assertTrue(interactorsExpected.contains(interactor.getInteractorAc()));
         }
+    }
 
+    @Test
+    public void filterByMultipleDetectionMethodMiIdentifiers() {
+        PagedInteractionSearchParameters params = PagedInteractionSearchParameters.builder()
+                .query("physical association")
+                .interactionDetectionMethodsFilter(Set.of(
+                        "MI:0029",
+                        "MI:0071"
+                )).build();
+
+        GroupPage<SearchChildInteractor> interactorOp = childInteractorSearchService.findInteractorsWithGroup(params);
+        assertEquals(4, interactorOp.getTotalElements());
+
+        long numInteractors = childInteractorSearchService.countInteractorsWithGroup(params);
+
+        assertEquals(4, numInteractors);
+
+        Set<String> interactorsExpected = new HashSet<>();
+        interactorsExpected.add("EBI-715849");
+        interactorsExpected.add("EBI-724102");
+        interactorsExpected.add("EBI-999909");
+        interactorsExpected.add("EBI-999900");
+
+        for (SearchChildInteractor interactor : interactorOp.getContent()) {
+            assertTrue(interactorsExpected.contains(interactor.getInteractorAc()));
+        }
+    }
+
+    @Test
+    public void filterByMultipleIdentificationMethods() {
+        PagedInteractionSearchParameters params = PagedInteractionSearchParameters.builder()
+                .query("physical association")
+                .participantDetectionMethodsFilter(Set.of(
+                        "tag perox activity",
+                        "western blot"
+                )).build();
+
+        GroupPage<SearchChildInteractor> interactorOp = childInteractorSearchService.findInteractorsWithGroup(params);
+        assertEquals(10, interactorOp.getTotalElements());
+        assertEquals(7, interactorOp.getContent().size());
+        // 10 participants found, with 7 distinct interactors, so total elements is 10,
+        // but then the content contains just 7 elements.
+
+        long numInteractors = childInteractorSearchService.countInteractorsWithGroup(params);
+
+        assertEquals(7, numInteractors);
+
+        Set<String> interactorsExpected = new HashSet<>();
+        interactorsExpected.add("EBI-10000824");
+        interactorsExpected.add("EBI-73886");
+        interactorsExpected.add("EBI-9997695");
+        interactorsExpected.add("EBI-7837133");
+        interactorsExpected.add("EBI-915507");
+        interactorsExpected.add("EBI-2028244");
+        interactorsExpected.add("EBI-4423297");
+
+        for (SearchChildInteractor interactor : interactorOp.getContent()) {
+            assertTrue(interactorsExpected.contains(interactor.getInteractorAc()));
+        }
+    }
+
+    @Test
+    public void filterByMultipleIdentificationMethodMiIdentifiers() {
+        PagedInteractionSearchParameters params = PagedInteractionSearchParameters.builder()
+                .query("physical association")
+                .participantDetectionMethodsFilter(Set.of(
+                        "MI:0981",
+                        "MI:0113"
+                )).build();
+
+        GroupPage<SearchChildInteractor> interactorOp = childInteractorSearchService.findInteractorsWithGroup(params);
+        assertEquals(10, interactorOp.getTotalElements());
+        assertEquals(7, interactorOp.getContent().size());
+        // 10 participants found, with 7 distinct interactors, so total elements is 10,
+        // but then the content contains just 7 elements.
+
+        long numInteractors = childInteractorSearchService.countInteractorsWithGroup(params);
+
+        assertEquals(7, numInteractors);
+
+        Set<String> interactorsExpected = new HashSet<>();
+        interactorsExpected.add("EBI-10000824");
+        interactorsExpected.add("EBI-73886");
+        interactorsExpected.add("EBI-9997695");
+        interactorsExpected.add("EBI-7837133");
+        interactorsExpected.add("EBI-915507");
+        interactorsExpected.add("EBI-2028244");
+        interactorsExpected.add("EBI-4423297");
+
+        for (SearchChildInteractor interactor : interactorOp.getContent()) {
+            assertTrue(interactorsExpected.contains(interactor.getInteractorAc()));
+        }
     }
 }

--- a/intact-search-interactions-service/src/test/java/uk/ac/ebi/intact/search/interactions/service/InteractionSearchServiceTest.java
+++ b/intact-search-interactions-service/src/test/java/uk/ac/ebi/intact/search/interactions/service/InteractionSearchServiceTest.java
@@ -324,6 +324,31 @@ public class InteractionSearchServiceTest {
             assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
         }
 
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0006__anti bait coip", 4L);
+        detectionMethodsStyledFacetsExpected.put("MI:0029__density sedimentation", 3L);
+        detectionMethodsStyledFacetsExpected.put("MI:0411__elisa", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0004__affinity chrom", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0071__molecular sieving", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(5, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        HashMap<String, Long> identificationMethodsFacetsExpected = new HashMap<>();
+        identificationMethodsFacetsExpected.put("MI:0396__predetermined", 5L);
+        identificationMethodsFacetsExpected.put("MI:0113__western blot", 4L);
+        identificationMethodsFacetsExpected.put("MI:0981__tag perox activity", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(3, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(identificationMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
         //interaction type facet checking
         HashMap<String, Long> interactionTypeFacetsExpected = new HashMap<>();
         interactionTypeFacetsExpected.put("MI:0915__physical association__#7bccc4", 10L);
@@ -437,11 +462,11 @@ public class InteractionSearchServiceTest {
         FacetPage<SearchInteraction> interactionFacetPage = interactionSearchService.findInteractionWithFacet(
                 PagedInteractionSearchParameters.builder()
                         .query("physical association")
-                        .interactorSpeciesFilter(Set.of("Homo sapiens"))
+                        .interactorSpeciesFilter(Set.of("Homo sapiens__9606"))
                         .interactionTypesFilter(Set.of("physical association"))
                         .interactionDetectionMethodsFilter(Set.of("molecular sieving"))
                         .interactorTypesFilter(Set.of("protein"))
-                        .interactionHostOrganismsFilter(Set.of("In vitro"))
+                        .interactionHostOrganismsFilter(Set.of("In vitro__-1"))
                         .minMIScore(0)
                         .maxMIScore(0.7)
                         .build()
@@ -493,6 +518,28 @@ public class InteractionSearchServiceTest {
         assertEquals(4, facetFieldEntryPage.getTotalElements());
         for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
             assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0029__density sedimentation", 3L);
+        detectionMethodsStyledFacetsExpected.put("MI:0411__elisa", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0004__affinity chrom", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0071__molecular sieving", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(4, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        HashMap<String, Long> identificationMethodsFacetsExpected = new HashMap<>();
+        identificationMethodsFacetsExpected.put("MI:0396__predetermined", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(1, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(identificationMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
         }
 
         //interaction type facet checking
@@ -568,11 +615,11 @@ public class InteractionSearchServiceTest {
         FacetPage<SearchInteraction> interactionFacetPage = interactionSearchService.findInteractionWithFacet(
                 PagedInteractionSearchParameters.builder()
                         .query("physical association")
-                        .interactorSpeciesFilter(Set.of("Homo sapiens", "Rattus norvegicus (Rat)"))
+                        .interactorSpeciesFilter(Set.of("Homo sapiens__9606", "Rattus norvegicus (Rat)__10116"))
                         .interactorTypesFilter(Set.of("protein"))
                         .interactionDetectionMethodsFilter(Set.of("molecular sieving"))
                         .interactionTypesFilter(Set.of("physical association"))
-                        .interactionHostOrganismsFilter(Set.of("In vitro"))
+                        .interactionHostOrganismsFilter(Set.of("In vitro__-1"))
                         .minMIScore(0)
                         .maxMIScore(0.6)
                         .intraSpeciesFilter(true)
@@ -611,6 +658,21 @@ public class InteractionSearchServiceTest {
         for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
             assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
         }
+
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0029__density sedimentation", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0411__elisa", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0004__affinity chrom", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(3, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(0, facetFieldEntryPage.getTotalElements());
 
         //interaction type facet checking
         facetFieldEntryPage = interactionFacetPage.getFacetResultPage(TYPE_MI_IDENTIFIER_STYLED);
@@ -704,6 +766,25 @@ public class InteractionSearchServiceTest {
         assertEquals(1, facetFieldEntryPage.getTotalElements());
         for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
             assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0006__anti bait coip", 4L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(1, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        HashMap<String, Long> identificationMethodsFacetsExpected = new HashMap<>();
+        identificationMethodsFacetsExpected.put("MI:0113__western blot", 4L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(1, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(identificationMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
         }
 
         //interaction type facet checking
@@ -826,6 +907,25 @@ public class InteractionSearchServiceTest {
         assertEquals(1, facetFieldEntryPage.getTotalElements());
         for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
             assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0411__elisa", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(1, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        HashMap<String, Long> identificationMethodsFacetsExpected = new HashMap<>();
+        identificationMethodsFacetsExpected.put("MI:0981__tag perox activity", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(1, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(identificationMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
         }
 
         //interaction type facet checking
@@ -952,6 +1052,31 @@ public class InteractionSearchServiceTest {
         assertEquals(5, facetFieldEntryPage.getTotalElements());
         for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
             assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0006__anti bait coip", 4L);
+        detectionMethodsStyledFacetsExpected.put("MI:0029__density sedimentation", 3L);
+        detectionMethodsStyledFacetsExpected.put("MI:0411__elisa", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0004__affinity chrom", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0071__molecular sieving", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(5, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        HashMap<String, Long> identificationMethodsFacetsExpected = new HashMap<>();
+        identificationMethodsFacetsExpected.put("MI:0396__predetermined", 5L);
+        identificationMethodsFacetsExpected.put("MI:0113__western blot", 4L);
+        identificationMethodsFacetsExpected.put("MI:0981__tag perox activity", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(3, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(identificationMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
         }
 
         //interaction type facet checking
@@ -1085,6 +1210,31 @@ public class InteractionSearchServiceTest {
             assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
         }
 
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0006__anti bait coip", 4L);
+        detectionMethodsStyledFacetsExpected.put("MI:0029__density sedimentation", 3L);
+        detectionMethodsStyledFacetsExpected.put("MI:0411__elisa", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0004__affinity chrom", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0071__molecular sieving", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(5, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        HashMap<String, Long> identificationMethodsFacetsExpected = new HashMap<>();
+        identificationMethodsFacetsExpected.put("MI:0396__predetermined", 5L);
+        identificationMethodsFacetsExpected.put("MI:0113__western blot", 4L);
+        identificationMethodsFacetsExpected.put("MI:0981__tag perox activity", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(3, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(identificationMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
         //interaction type facet checking
         HashMap<String, Long> interactionTypeFacetsExpected = new HashMap<>();
         interactionTypeFacetsExpected.put("MI:0915__physical association__#7bccc4", 10L);
@@ -1210,6 +1360,26 @@ public class InteractionSearchServiceTest {
         assertEquals(2, facetFieldEntryPage.getTotalElements());
         for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
             assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0029__density sedimentation", 3L);
+        detectionMethodsStyledFacetsExpected.put("MI:0071__molecular sieving", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(2, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        HashMap<String, Long> identificationMethodsFacetsExpected = new HashMap<>();
+        identificationMethodsFacetsExpected.put("MI:0396__predetermined", 4L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(1, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(identificationMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
         }
 
         //interaction type facet checking
@@ -1352,6 +1522,30 @@ public class InteractionSearchServiceTest {
             assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
         }
 
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0029__density sedimentation", 3L);
+        detectionMethodsStyledFacetsExpected.put("MI:0411__elisa", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0004__affinity chrom", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0071__molecular sieving", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(4, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        HashMap<String, Long> identificationMethodsFacetsExpected = new HashMap<>();
+        identificationMethodsFacetsExpected.put("MI:0396__predetermined", 5L);
+        identificationMethodsFacetsExpected.put("MI:0113__western blot", 4L);
+        identificationMethodsFacetsExpected.put("MI:0981__tag perox activity", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(2, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(identificationMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
         //interaction type facet checking
         HashMap<String, Long> interactionTypeFacetsExpected = new HashMap<>();
         interactionTypeFacetsExpected.put("MI:0915__physical association__#7bccc4", 6L);
@@ -1490,6 +1684,30 @@ public class InteractionSearchServiceTest {
             assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
         }
 
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0029__density sedimentation", 3L);
+        detectionMethodsStyledFacetsExpected.put("MI:0411__elisa", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0004__affinity chrom", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0071__molecular sieving", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(4, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        HashMap<String, Long> identificationMethodsFacetsExpected = new HashMap<>();
+        identificationMethodsFacetsExpected.put("MI:0396__predetermined", 5L);
+        identificationMethodsFacetsExpected.put("MI:0113__western blot", 4L);
+        identificationMethodsFacetsExpected.put("MI:0981__tag perox activity", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(2, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(identificationMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
         //interaction type facet checking
         HashMap<String, Long> interactionTypeFacetsExpected = new HashMap<>();
         interactionTypeFacetsExpected.put("MI:0915__physical association__#7bccc4", 6L);
@@ -1561,11 +1779,10 @@ public class InteractionSearchServiceTest {
      **/
     @Test
     public void filterByMultipleDetectionMethods() {
-
         FacetPage<SearchInteraction> interactionFacetPage = interactionSearchService.findInteractionWithFacet(
                 PagedInteractionSearchParameters.builder()
                         .query("physical association")
-                        .interactionDetectionMethodsFilter(Set.of("density sedimentation", "molecular sieving"))
+                        .interactionDetectionMethodsFilter(Set.of("MI:0029", "MI:0071"))
                         .build()
         );
 
@@ -1625,6 +1842,29 @@ public class InteractionSearchServiceTest {
         assertEquals(5, facetFieldEntryPage.getTotalElements());
         for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
             assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0006__anti bait coip", 4L);
+        detectionMethodsStyledFacetsExpected.put("MI:0029__density sedimentation", 3L);
+        detectionMethodsStyledFacetsExpected.put("MI:0411__elisa", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0004__affinity chrom", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0071__molecular sieving", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(5, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        HashMap<String, Long> identificationMethodsFacetsExpected = new HashMap<>();
+        identificationMethodsFacetsExpected.put("MI:0396__predetermined", 4L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(1, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(identificationMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
         }
 
         //interaction type facet checking
@@ -1691,6 +1931,166 @@ public class InteractionSearchServiceTest {
         }
     }
 
+    @Test
+    public void filterByMultipleIdentificationMethods() {
+        FacetPage<SearchInteraction> interactionFacetPage = interactionSearchService.findInteractionWithFacet(
+                PagedInteractionSearchParameters.builder()
+                        .query("physical association")
+//                        .participantDetectionMethodsFilter(Set.of("predetermined", "tag perox activity"))
+                        .participantDetectionMethodsFilter(Set.of("MI:0396", "MI:0981"))
+                        .build()
+        );
+
+        // page checks
+        assertFalse(interactionFacetPage.getContent().isEmpty());
+        assertEquals(6, interactionFacetPage.getContent().size());
+        assertEquals(6, interactionFacetPage.getNumberOfElements());
+        assertEquals(0, interactionFacetPage.getPageable().getPageNumber());
+        assertEquals(10, interactionFacetPage.getPageable().getPageSize());
+        assertEquals(6, interactionFacetPage.getTotalElements());
+
+        Set<String> interactionsExpected = new HashSet<>();
+        interactionsExpected.add("EBI-1000008");
+        interactionsExpected.add("EBI-1000026");
+        interactionsExpected.add("EBI-1000048");
+        interactionsExpected.add("EBI-10000862");
+
+        for (SearchInteraction interaction : interactionFacetPage.getContent()) {
+            assertTrue(interactionsExpected.contains(interaction.getAc()));
+        }
+
+        //facet checking
+        //species facet checking
+        HashMap<String, Long> specieFacetsExpected = new HashMap<>();
+        specieFacetsExpected.put("9606__Homo sapiens__#335e94", 6L);
+
+        Page<FacetFieldEntry> facetFieldEntryPage = interactionFacetPage.getFacetResultPage(TAX_ID_A_B_STYLED);
+        assertEquals(1, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(specieFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        // intra species, in these case the number are the same than TAX_ID_A_B_STYLED
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(INTRA_TAX_ID_STYLED);
+        assertEquals(1, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(specieFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //interactor type facet checking
+        HashMap<String, Long> interactorTypeFacetsExpected = new HashMap<>();
+        interactorTypeFacetsExpected.put("MI:0326__protein__ELLIPSE", 6L);
+        interactorTypeFacetsExpected.put("MI:0319__dna__VEE", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(TYPE_MI_A_B_STYLED);
+        assertEquals(2, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(interactorTypeFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //detection method facet checking
+        HashMap<String, Long> detectionMethodsFacetsExpected = new HashMap<>();
+        detectionMethodsFacetsExpected.put("density sedimentation", 3L);
+        detectionMethodsFacetsExpected.put("molecular sieving", 1L);
+        detectionMethodsFacetsExpected.put("elisa", 1L);
+        detectionMethodsFacetsExpected.put("affinity chrom", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_S);
+        assertEquals(4, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0029__density sedimentation", 3L);
+        detectionMethodsStyledFacetsExpected.put("MI:0411__elisa", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0004__affinity chrom", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0071__molecular sieving", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(4, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        HashMap<String, Long> identificationMethodsFacetsExpected = new HashMap<>();
+        identificationMethodsFacetsExpected.put("MI:0396__predetermined", 5L);
+        identificationMethodsFacetsExpected.put("MI:0113__western blot", 4L);
+        identificationMethodsFacetsExpected.put("MI:0981__tag perox activity", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(3, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(identificationMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //interaction type facet checking
+        HashMap<String, Long> interactionTypeFacetsExpected = new HashMap<>();
+        interactionTypeFacetsExpected.put("MI:0915__physical association__#7bccc4", 6L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(TYPE_MI_IDENTIFIER_STYLED);
+        assertEquals(1, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(interactionTypeFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //host organism facet checking
+        HashMap<String, Long> hostOrganismFacetsExpected = new HashMap<>();
+        hostOrganismFacetsExpected.put("-1__In vitro__#8d6666", 6L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(HOST_ORGANISM_TAXID_STYLED);
+        assertEquals(1, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(hostOrganismFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        // negative facet checking
+        HashMap<String, Long> negativeFacetsExpected = new HashMap<>();
+        negativeFacetsExpected.put("false", 6L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(NEGATIVE);
+        assertEquals(1, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(negativeFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        // affected by mutation
+        HashMap<String, Long> mutationFacetsExpected = new HashMap<>();
+        mutationFacetsExpected.put("none__false__#7e8389", 6L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(AFFECTED_BY_MUTATION_STYLED);
+        assertEquals(1, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(mutationFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        // MIscore facet checking
+        HashMap<String, Long> miScoreFacetsExpected = new HashMap<>();
+        miScoreFacetsExpected.put("0.64", 2L);
+        miScoreFacetsExpected.put("0.56", 1L);
+        miScoreFacetsExpected.put("0.4", 1L);
+        miScoreFacetsExpected.put("0.53", 1L);
+        miScoreFacetsExpected.put("0.69", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(INTACT_MISCORE);
+        assertEquals(5, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(miScoreFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        // expansion method facet checking
+        HashMap<String, Long> expansionMethodExpected = new HashMap<>();
+        expansionMethodExpected.put("expansion_true", 3L);
+        expansionMethodExpected.put("expansion_false", 3L);
+
+        Page<FacetQueryEntry> facetPageFacetQueryResult = interactionFacetPage.getFacetQueryResult();
+        assertEquals(2, facetPageFacetQueryResult.getTotalElements());
+        for (FacetQueryEntry facetQueryEntry : facetPageFacetQueryResult) {
+            assertEquals(expansionMethodExpected.get(facetQueryEntry.getValue()), new Long(facetQueryEntry.getValueCount()));
+        }
+    }
+
     /*
      * Expected interactions/facets when queried and filtered by multiple host organism
      **/
@@ -1701,8 +2101,8 @@ public class InteractionSearchServiceTest {
                 PagedInteractionSearchParameters.builder()
                         .query("physical association")
                         .interactionHostOrganismsFilter(Set.of(
-                                "In vitro",
-                                "rattus norvegicus liver")
+                                "In vitro__-1",
+                                "rattus norvegicus liver__10116")
                         ).build()
         );
 
@@ -1755,6 +2155,31 @@ public class InteractionSearchServiceTest {
         assertEquals(5, facetFieldEntryPage.getTotalElements());
         for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
             assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0006__anti bait coip", 4L);
+        detectionMethodsStyledFacetsExpected.put("MI:0029__density sedimentation", 3L);
+        detectionMethodsStyledFacetsExpected.put("MI:0411__elisa", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0004__affinity chrom", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0071__molecular sieving", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(5, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        HashMap<String, Long> identificationMethodsFacetsExpected = new HashMap<>();
+        identificationMethodsFacetsExpected.put("MI:0396__predetermined", 5L);
+        identificationMethodsFacetsExpected.put("MI:0113__western blot", 4L);
+        identificationMethodsFacetsExpected.put("MI:0981__tag perox activity", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(3, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(identificationMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
         }
 
         //interaction type facet checking
@@ -1830,7 +2255,7 @@ public class InteractionSearchServiceTest {
     @Test
     public void filterByInteractionType() {
 
-        Set<String> interactionTypesFilter = Set.of("physical association");
+        Set<String> interactionTypesFilter = Set.of("MI:0915");
 
         FacetPage<SearchInteraction> interactionFacetPage = interactionSearchService.findInteractionWithFacet(
                 PagedInteractionSearchParameters.builder()
@@ -1888,6 +2313,31 @@ public class InteractionSearchServiceTest {
         assertEquals(5, facetFieldEntryPage.getTotalElements());
         for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
             assertEquals(detectionMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        HashMap<String, Long> detectionMethodsStyledFacetsExpected = new HashMap<>();
+        detectionMethodsStyledFacetsExpected.put("MI:0006__anti bait coip", 4L);
+        detectionMethodsStyledFacetsExpected.put("MI:0029__density sedimentation", 3L);
+        detectionMethodsStyledFacetsExpected.put("MI:0411__elisa", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0004__affinity chrom", 1L);
+        detectionMethodsStyledFacetsExpected.put("MI:0071__molecular sieving", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(DETECTION_METHOD_MI_STYLED);
+        assertEquals(5, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(detectionMethodsStyledFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
+        }
+
+        //identification method facet checking
+        HashMap<String, Long> identificationMethodsFacetsExpected = new HashMap<>();
+        identificationMethodsFacetsExpected.put("MI:0396__predetermined", 5L);
+        identificationMethodsFacetsExpected.put("MI:0113__western blot", 4L);
+        identificationMethodsFacetsExpected.put("MI:0981__tag perox activity", 1L);
+
+        facetFieldEntryPage = interactionFacetPage.getFacetResultPage(IDENTIFICATION_METHOD_MI_A_B_STYLED);
+        assertEquals(3, facetFieldEntryPage.getTotalElements());
+        for (FacetFieldEntry facetFieldEntry : facetFieldEntryPage) {
+            assertEquals(identificationMethodsFacetsExpected.get(facetFieldEntry.getValue()), new Long(facetFieldEntry.getValueCount()));
         }
 
         //interaction type facet checking

--- a/intact-search-interactions-service/src/test/resources/Interactions.xml
+++ b/intact-search-interactions-service/src/test/resources/Interactions.xml
@@ -1921,6 +1921,51 @@
     <void property="typeMIIdentifierStyled">
      <string>MI:0915__physical association__#7bccc4</string>
     </void>
+    <void property="detectionMethodMIIdentifierStyled">
+     <string>MI:0071__molecular sieving</string>
+    </void>
+    <void property="identificationMethodsA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodsB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIAStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396__predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIBStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396__predetermined</string>
+      </void>
+     </object>
+    </void>
     <void property="uniqueIdA">
      <string>Q9BZD4</string>
     </void>
@@ -3728,6 +3773,51 @@
     </void>
     <void property="typeMIIdentifierStyled">
      <string>MI:0915__physical association__#7bccc4</string>
+    </void>
+    <void property="detectionMethodMIIdentifierStyled">
+     <string>MI:0004__affinity chrom</string>
+    </void>
+    <void property="identificationMethodsA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodsB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIAStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396__predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIBStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396__predetermined</string>
+      </void>
+     </object>
     </void>
     <void property="uniqueIdA">
      <string>Q8NBT2</string>
@@ -5759,6 +5849,51 @@
     </void>
     <void property="typeMIIdentifierStyled">
      <string>MI:0915__physical association__#7bccc4</string>
+    </void>
+    <void property="detectionMethodMIIdentifierStyled">
+     <string>MI:0029__density sedimentation</string>
+    </void>
+    <void property="identificationMethodsA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodsB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIAStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396__predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIBStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396__predetermined</string>
+      </void>
+     </object>
     </void>
     <void property="uniqueIdA">
      <string>O14777</string>
@@ -7803,6 +7938,51 @@
     </void>
     <void property="typeMIIdentifierStyled">
      <string>MI:0915__physical association__#7bccc4</string>
+    </void>
+    <void property="detectionMethodMIIdentifierStyled">
+     <string>MI:0029__density sedimentation</string>
+    </void>
+    <void property="identificationMethodsA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodsB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIAStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396__predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIBStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396__predetermined</string>
+      </void>
+     </object>
     </void>
     <void property="uniqueIdA">
      <string>O14777</string>
@@ -9938,6 +10118,51 @@
     <void property="typeMIIdentifierStyled">
      <string>MI:0915__physical association__#7bccc4</string>
     </void>
+    <void property="detectionMethodMIIdentifierStyled">
+     <string>MI:0029__density sedimentation</string>
+    </void>
+    <void property="identificationMethodsA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodsB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIAStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396__predetermined</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIBStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0396__predetermined</string>
+      </void>
+     </object>
+    </void>
     <void property="uniqueIdA">
      <string>O14777</string>
     </void>
@@ -11706,6 +11931,51 @@
     <void property="typeMIIdentifierStyled">
      <string>MI:0915__physical association__#7bccc4</string>
     </void>
+    <void property="detectionMethodMIIdentifierStyled">
+     <string>MI:0006__anti bait coip</string>
+    </void>
+    <void property="identificationMethodsA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>western blot</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodsB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>western blot</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIAStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113__western blot</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIBStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113__western blot</string>
+      </void>
+     </object>
+    </void>
     <void property="uniqueIdA">
      <string>O35152</string>
     </void>
@@ -13432,6 +13702,51 @@
     </void>
     <void property="typeMIIdentifierStyled">
      <string>MI:0915__physical association__#7bccc4</string>
+    </void>
+    <void property="detectionMethodMIIdentifierStyled">
+     <string>MI:0006__anti bait coip</string>
+    </void>
+    <void property="identificationMethodsA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>western blot</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodsB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>western blot</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIAStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113__western blot</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIBStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113__western blot</string>
+      </void>
+     </object>
     </void>
     <void property="uniqueIdA">
      <string>O35152</string>
@@ -15252,6 +15567,51 @@
     <void property="typeMIIdentifierStyled">
      <string>MI:0915__physical association__#7bccc4</string>
     </void>
+    <void property="detectionMethodMIIdentifierStyled">
+     <string>MI:0006__anti bait coip</string>
+    </void>
+    <void property="identificationMethodsA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>western blot</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodsB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>western blot</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIAStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113__western blot</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIBStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113__western blot</string>
+      </void>
+     </object>
+    </void>
     <void property="uniqueIdA">
      <string>O35152</string>
     </void>
@@ -17022,6 +17382,51 @@
     </void>
     <void property="typeMIIdentifierStyled">
      <string>MI:0915__physical association__#7bccc4</string>
+    </void>
+    <void property="detectionMethodMIIdentifierStyled">
+     <string>MI:0006__anti bait coip</string>
+    </void>
+    <void property="identificationMethodsA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>western blot</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodsB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>western blot</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIAStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113__western blot</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIBStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0113__western blot</string>
+      </void>
+     </object>
     </void>
     <void property="uniqueIdA">
      <string>O35152</string>
@@ -19849,6 +20254,51 @@
     </void>
     <void property="typeMIIdentifierStyled">
      <string>MI:0915__physical association__#7bccc4</string>
+    </void>
+    <void property="detectionMethodMIIdentifierStyled">
+     <string>MI:0411__elisa</string>
+    </void>
+    <void property="identificationMethodsA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>tag perox activity</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodsB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>tag perox activity</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersA">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0981</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIIdentifiersB">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0981</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIAStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0981__tag perox activity</string>
+      </void>
+     </object>
+    </void>
+    <void property="identificationMethodMIBStyled">
+     <object class="java.util.HashSet">
+      <void method="add">
+       <string>MI:0981__tag perox activity</string>
+      </void>
+     </object>
     </void>
     <void property="uniqueIdA">
      <string>EBI-10000824</string>

--- a/intact-search-interactions-service/src/test/resources/solr.home.7.3.1/interactions/conf/managed-schema
+++ b/intact-search-interactions-service/src/test/resources/solr.home.7.3.1/interactions/conf/managed-schema
@@ -12,6 +12,7 @@
   </fieldType>
   <fieldType name="binary" class="solr.BinaryField"/>
   <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
+  <fieldType name="boolean_intact" class="solr.BoolField" indexed="true" stored="false" sortMissingLast="true"/>
   <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
   <fieldType name="delimited_payloads_float" class="solr.TextField" indexed="true" stored="false">
     <analyzer>
@@ -39,6 +40,8 @@
       <tokenizer class="solr.KeywordTokenizerFactory"/>
     </analyzer>
   </fieldType>
+  <fieldType name="double_intact" class="solr.DoublePointField" indexed="true" stored="false" multiValued="false"/>
+  <fieldType name="int_intact" class="solr.TrieIntField" indexed="true" stored="false" positionIncrementGap="0" multiValued="false" precisionStep="0" required="true"/>
   <fieldType name="intact_identifier" class="solr.TextField" positionIncrementGap="100" multiValued="true">
     <analyzer type="index">
       <charFilter class="solr.PatternReplaceFilterFactory" pattern="[\:\-\(\)]" replacement=""/>
@@ -300,27 +303,6 @@
       <filter class="solr.LowerCaseFilterFactory"/>
     </analyzer>
   </fieldType>
-  <!-- used exclusively for advanced search - start -->
-  <fieldType name="text_intact" class="solr.TextField" positionIncrementGap="100" indexed="true" stored="false" omitNorms="true" termVectors="true" required="true" multiValued="true">
-    <analyzer>
-      <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[\(\)]" replacement=""/>
-      <!-- replace brakets -->
-      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-      <filter class="solr.TrimFilterFactory"/>
-      <!--
-        trim white spaces at the beginning and end of the words
-      -->
-      <filter class="solr.LowerCaseFilterFactory"/>
-      <filter class="solr.StopFilterFactory"/>
-      <!--
-        discards common english stop words: "a", "an", ...
-      -->
-  </analyzer>
-  </fieldType>
-  <fieldType name="int_intact" class="solr.TrieIntField" indexed="true" stored="false" precisionStep="0" positionIncrementGap="0" multiValued="false" required="true"/>
-  <fieldType name="double_intact" class="solr.DoublePointField"  indexed="true" stored="false" multiValued="false"/>
-  <fieldType name="boolean_intact" class="solr.BoolField" indexed="true" stored="false" sortMissingLast="true"/>
-  <!-- used exclusively for advanced search - end -->
   <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
     <analyzer type="index">
       <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -388,6 +370,15 @@
       <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="solr.StopFilterFactory" words="lang/stopwords_id.txt" ignoreCase="true"/>
       <filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
+    </analyzer>
+  </fieldType>
+  <fieldType name="text_intact" class="solr.TextField" omitNorms="true" indexed="true" stored="false" positionIncrementGap="100" termVectors="true" multiValued="true" required="true">
+    <analyzer>
+      <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[\(\)]" replacement=""/>
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+      <filter class="solr.TrimFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.StopFilterFactory"/>
     </analyzer>
   </fieldType>
   <fieldType name="text_it" class="solr.TextField" positionIncrementGap="100">
@@ -503,6 +494,57 @@
   <field name="annotations" type="text_general" multiValued="true"/>
   <field name="annotationsA" type="text_general" multiValued="true"/>
   <field name="annotationsB" type="text_general" multiValued="true"/>
+  <field name="as_alias" type="text_intact" default=""/>
+  <field name="as_aliasA" type="text_intact" default="-"/>
+  <field name="as_aliasB" type="text_intact" default="-"/>
+  <field name="as_altidA" type="text_intact" default="-"/>
+  <field name="as_altidB" type="text_intact" default="-"/>
+  <field name="as_annot" type="text_intact" default=""/>
+  <field name="as_complex" type="text_intact" default="-"/>
+  <field name="as_detmethod" type="text_intact" default="-"/>
+  <field name="as_ftype" type="text_intact" default=""/>
+  <field name="as_ftypeA" type="text_intact" default="-"/>
+  <field name="as_ftypeB" type="text_intact" default="-"/>
+  <field name="as_geneName" type="text_intact" default=""/>
+  <field name="as_geneNameA" type="text_intact" default="-"/>
+  <field name="as_geneNameB" type="text_intact" default="-"/>
+  <field name="as_id" type="text_intact" default=""/>
+  <field name="as_idA" type="text_intact" default="-"/>
+  <field name="as_idB" type="text_intact" default="-"/>
+  <field name="as_identifier" type="text_intact" default=""/>
+  <field name="as_intact-miscore" type="double_intact" default="0"/>
+  <field name="as_interaction_id" type="text_intact" default="-"/>
+  <field name="as_mutation" type="boolean_intact" default="false"/>
+  <field name="as_mutationA" type="boolean_intact" default="false"/>
+  <field name="as_mutationB" type="boolean_intact" default="false"/>
+  <field name="as_negative" type="boolean_intact" default="false"/>
+  <field name="as_param" type="boolean_intact" default="false"/>
+  <field name="as_pbiorole" type="text_intact" default=""/>
+  <field name="as_pbioroleA" type="text_intact" default="-"/>
+  <field name="as_pbioroleB" type="text_intact" default="-"/>
+  <field name="as_pmethod" type="text_intact" default=""/>
+  <field name="as_pmethodA" type="text_intact" default="-"/>
+  <field name="as_pmethodB" type="text_intact" default="-"/>
+  <field name="as_ptype" type="text_intact" default=""/>
+  <field name="as_ptypeA" type="text_intact" default="-"/>
+  <field name="as_ptypeB" type="text_intact" default="-"/>
+  <field name="as_pubauth" type="text_intact" default="-"/>
+  <field name="as_pubauthors" type="text_intact" default="-"/>
+  <field name="as_pubid" type="text_intact" default="-"/>
+  <field name="as_pubyear" type="int_intact" default="0"/>
+  <field name="as_pxref" type="text_intact" default=""/>
+  <field name="as_pxrefA" type="text_intact" default="-"/>
+  <field name="as_pxrefB" type="text_intact" default="-"/>
+  <field name="as_rdate" type="int_intact" default="0"/>
+  <field name="as_source" type="text_intact" default="-"/>
+  <field name="as_species" type="text_intact" default=""/>
+  <field name="as_stc" type="boolean_intact" default="false"/>
+  <field name="as_taxidA" type="text_intact" default="-"/>
+  <field name="as_taxidB" type="text_intact" default="-"/>
+  <field name="as_taxidHost" type="text_intact" default="-"/>
+  <field name="as_type" type="text_intact" default="-"/>
+  <field name="as_udate" type="int_intact" default="0"/>
+  <field name="as_xref" type="text_intact" default="-"/>
   <field name="author" type="text_general"/>
   <field name="binary_interaction_id" type="plong"/>
   <field name="biological_role_A" type="text_general"/>
@@ -520,6 +562,7 @@
   <field name="descriptionB" type="text_general"/>
   <field name="detection_method" type="text_general"/>
   <field name="detection_method_mi_identifier" type="text_general"/>
+  <field name="detection_method_mi_styled" type="string"/>
   <field name="document_type" type="text_general"/>
   <field name="expansion_method" type="text_general"/>
   <field name="experimental_preparations_A" type="text_general" multiValued="true"/>
@@ -546,6 +589,9 @@
   <field name="idB" type="text_general"/>
   <field name="identification_method_A" type="text_general" multiValued="true"/>
   <field name="identification_method_B" type="text_general" multiValued="true"/>
+  <field name="identification_method_mi_A_B_styled" type="strings"/>
+  <field name="identification_method_mi_A_styled" type="strings"/>
+  <field name="identification_method_mi_B_styled" type="strings"/>
   <field name="identification_method_mi_identifier_A" type="text_general" multiValued="true"/>
   <field name="identification_method_mi_identifier_B" type="text_general" multiValued="true"/>
   <field name="identifiers" type="text_general" multiValued="true"/>
@@ -553,8 +599,6 @@
   <field name="intactNameB" type="text_general"/>
   <field name="intact_miscore" type="pdouble"/>
   <field name="interaction_count" type="plong"/>
-
-  <!-- interactor_* fields are likely to be only stored, currently we are not using them for searching  -->
   <field name="interactor_alias" type="text_general" multiValued="true"/>
   <field name="interactor_alt_ids" type="text_general" multiValued="true"/>
   <field name="interactor_default" type="text_general" multiValued="true" indexed="true" stored="false"/>
@@ -573,6 +617,8 @@
   <field name="intra_species" type="string" indexed="true" stored="true"/>
   <field name="intra_taxId" type="plong"/>
   <field name="intra_taxId_styled" type="string"/>
+  <field name="jsonFormat" type="text_general"/>
+  <field name="json_format" type="text_general"/>
   <field name="moleculeA" type="text_general"/>
   <field name="moleculeB" type="text_general"/>
   <field name="mutation_A" type="boolean"/>
@@ -585,11 +631,19 @@
   <field name="publication_id" type="string"/>
   <field name="publication_identifiers" type="text_general" multiValued="true"/>
   <field name="release_date" type="pdate"/>
+  <field name="serialised_interaction" type="text_general"/>
+  <field name="serialised_xml" type="text_general"/>
   <field name="source_database" type="text_general"/>
   <field name="speciesA" type="text_general"/>
   <field name="speciesB" type="text_general"/>
   <field name="stoichiometry_A" type="text_general"/>
   <field name="stoichiometry_B" type="text_general"/>
+  <field name="tab25Format" type="text_general"/>
+  <field name="tab26Format" type="text_general"/>
+  <field name="tab27Format" type="text_general"/>
+  <field name="tab_25_format" type="text_general"/>
+  <field name="tab_26_format" type="text_general"/>
+  <field name="tab_27_format" type="text_general"/>
   <field name="taxIdA" type="plong"/>
   <field name="taxIdA_styled" type="string"/>
   <field name="taxIdB" type="plong"/>
@@ -609,64 +663,13 @@
   <field name="uniqueIdB" type="text_general"/>
   <field name="uniqueKey" type="text_general"/>
   <field name="updation_date" type="pdate"/>
+  <field name="xml25Format" type="text_general"/>
+  <field name="xml30Format" type="text_general"/>
+  <field name="xml_25_format" type="text_general"/>
+  <field name="xml_30_format" type="text_general"/>
   <field name="xrefs" type="text_general" multiValued="true"/>
   <field name="xrefsA" type="text_general" multiValued="true"/>
   <field name="xrefsB" type="text_general" multiValued="true"/>
-
-  <!-- Advance Search Fields -->
-
-  <field name="as_idA" type="text_intact" default="-" />
-  <field name="as_idB" type="text_intact" default="-" />
-  <field name="as_altidA" type="text_intact" default="-" />
-  <field name="as_altidB" type="text_intact" default="-" />
-  <field name="as_id" type="text_intact" default=""/><!-- id = altA+altB (alt ids contain idA and idB) -->
-  <field name="as_aliasA" type="text_intact" default="-"/>
-  <field name="as_aliasB" type="text_intact" default="-"/>
-  <field name="as_alias" type="text_intact" default=""/><!-- alias = aliasA+aliasB -->
-  <field name="as_identifier" type="text_intact" default=""/><!-- identifier = id + alias -->
-  <field name="as_pubid" type="text_intact" default="-"/>
-  <field name="as_interaction_id" type="text_intact" default="-"/>
-  <field name="as_taxidA" type="text_intact" default="-"/>
-  <field name="as_taxidB" type="text_intact" default="-"/>
-  <field name="as_species" type="text_intact" default=""/><!-- species = taxidA + taxidB -->
-  <field name="as_taxidHost" type="text_intact" default="-"/>
-  <field name="as_pubauth" type="text_intact" default="-"/>
-  <field name="as_pubauthors" type="text_intact" default="-"/>
-  <field name="as_pubyear" type="int_intact" default="0"/>
-  <field name="as_type" type="text_intact" default="-"/>
-  <field name="as_detmethod" type="text_intact" default="-"/>
-  <field name="as_pbioroleA" type="text_intact" default="-"/>
-  <field name="as_pbioroleB" type="text_intact" default="-"/>
-  <field name="as_pbiorole" type="text_intact" default=""/><!-- pbiorole = pbioroleA + pbioroleB -->
-  <field name="as_ptypeA" type="text_intact" default="-"/>
-  <field name="as_ptypeB" type="text_intact" default="-"/>
-  <field name="as_ptype" type="text_intact" default=""/><!-- ptype = ptypeA + ptypeB -->
-  <field name="as_ftypeA" type="text_intact" default="-"/>
-  <field name="as_ftypeB" type="text_intact" default="-"/>
-  <field name="as_ftype" type="text_intact" default=""/> <!-- ftype = ftypeA + ftypeB -->
-  <field name="as_pmethodA" type="text_intact" default="-"/>
-  <field name="as_pmethodB" type="text_intact" default="-"/>
-  <field name="as_pmethod" type="text_intact" default=""/><!-- pmethod = pmethodA + pmethodB -->
-  <field name="as_pxrefA" type="text_intact" default="-"/>
-  <field name="as_pxrefB" type="text_intact" default="-"/>
-  <field name="as_pxref" type="text_intact" default=""/><!-- pxref = pxrefA + pxrefB -->
-  <field name="as_xref" type="text_intact" default="-"/>
-  <field name="as_complex" type="text_intact" default="-"/>
-  <field name="as_source" type="text_intact" default="-"/>
-  <field name="as_udate" type="int_intact" default="0"/>
-  <field name="as_rdate" type="int_intact" default="0"/>
-  <field name="as_intact-miscore" type="double_intact" default="0"/>
-  <field name="as_negative" type="boolean_intact" default="false"/>
-  <field name="as_param" type="boolean_intact" default="false"/>
-  <field name="as_stc" type="boolean_intact" default="false"/>
-  <field name="as_mutation" type="boolean_intact" default="false"/>
-  <field name="as_mutationA" type="boolean_intact" default="false"/>
-  <field name="as_mutationB" type="boolean_intact" default="false"/>
-  <field name="as_annot" type="text_intact" default=""/>
-  <field name="as_geneNameA" type="text_intact" default="-"/>
-  <field name="as_geneNameB" type="text_intact" default="-"/>
-  <field name="as_geneName" type="text_intact" default=""/><!-- geneName = geneNameA + geneNameB -->
-
   <dynamicField name="*_txt_en_split_tight" type="text_en_splitting_tight" indexed="true" stored="true"/>
   <dynamicField name="*_descendent_path" type="descendent_path" indexed="true" stored="true"/>
   <dynamicField name="*_ancestor_path" type="ancestor_path" indexed="true" stored="true"/>
@@ -733,14 +736,87 @@
   <dynamicField name="*_f" type="pfloat" indexed="true" stored="true"/>
   <dynamicField name="*_d" type="pdouble" indexed="true" stored="true"/>
   <dynamicField name="*_p" type="location" indexed="true" stored="true"/>
-  <!-- interactor_default can be replace in a query by interactor_identifiers or aliasesA or aliasesB
- and can simplify problems of identifiers with '-' or numbers -->
+  <copyField source="aliasesA" dest="default"/>
   <copyField source="aliasesA" dest="interactor_default"/>
+  <copyField source="aliasesB" dest="default"/>
   <copyField source="aliasesB" dest="interactor_default"/>
+  <copyField source="altIdsA" dest="default"/>
   <copyField source="altIdsA" dest="interactor_default"/>
+  <copyField source="altIdsB" dest="default"/>
   <copyField source="altIdsB" dest="interactor_default"/>
+  <copyField source="as_aliasA" dest="as_alias"/>
+  <copyField source="as_aliasA" dest="as_identifier"/>
+  <copyField source="as_aliasB" dest="as_alias"/>
+  <copyField source="as_aliasB" dest="as_identifier"/>
+  <copyField source="as_altidA" dest="as_id"/>
+  <copyField source="as_altidA" dest="as_identifier"/>
+  <copyField source="as_altidB" dest="as_id"/>
+  <copyField source="as_altidB" dest="as_identifier"/>
+  <copyField source="as_ftypeA" dest="as_ftype"/>
+  <copyField source="as_ftypeB" dest="as_ftype"/>
+  <copyField source="as_geneNameA" dest="as_geneName"/>
+  <copyField source="as_geneNameB" dest="as_geneName"/>
+  <copyField source="as_pbioroleA" dest="as_pbiorole"/>
+  <copyField source="as_pbioroleB" dest="as_pbiorole"/>
+  <copyField source="as_pmethodA" dest="as_pmethod"/>
+  <copyField source="as_pmethodB" dest="as_pmethod"/>
+  <copyField source="as_ptypeA" dest="as_ptype"/>
+  <copyField source="as_ptypeB" dest="as_ptype"/>
+  <copyField source="as_pxrefA" dest="as_pxref"/>
+  <copyField source="as_pxrefB" dest="as_pxref"/>
+  <copyField source="as_taxidA" dest="as_species"/>
+  <copyField source="as_taxidB" dest="as_species"/>
+  <copyField source="descriptionA" dest="default"/>
+  <copyField source="descriptionB" dest="default"/>
+  <copyField source="detection_method" dest="default"/>
+  <copyField source="detection_method_mi_identifier" dest="default"/>
+  <copyField source="feature_ranges_A" dest="default"/>
+  <copyField source="feature_ranges_B" dest="default"/>
+  <copyField source="feature_shortlabel_A" dest="default"/>
+  <copyField source="feature_shortlabel_B" dest="default"/>
+  <copyField source="feature_type_A" dest="default"/>
+  <copyField source="feature_type_B" dest="default"/>
+  <copyField source="first_author" dest="default"/>
+  <copyField source="host_organism" dest="default"/>
+  <copyField source="host_organism_taxId" dest="default"/>
+  <copyField source="idA" dest="default"/>
   <copyField source="idA" dest="interactor_default"/>
+  <copyField source="idB" dest="default"/>
   <copyField source="idB" dest="interactor_default"/>
+  <copyField source="identification_method_A" dest="default"/>
+  <copyField source="identification_method_B" dest="default"/>
+  <copyField source="identification_method_mi_A_styled" dest="identification_method_mi_A_B_styled"/>
+  <copyField source="identification_method_mi_B_styled" dest="identification_method_mi_A_B_styled"/>
+  <copyField source="identification_method_mi_identifier_A" dest="default"/>
+  <copyField source="identification_method_mi_identifier_B" dest="default"/>
+  <copyField source="identifiers" dest="default"/>
+  <copyField source="intactNameA" dest="default"/>
+  <copyField source="intactNameB" dest="default"/>
+  <copyField source="moleculeA" dest="default"/>
+  <copyField source="moleculeB" dest="default"/>
+  <copyField source="parameter_types" dest="default"/>
+  <copyField source="publication_annotations" dest="default"/>
+  <copyField source="publication_authors" dest="default"/>
+  <copyField source="publication_identifiers" dest="default"/>
+  <copyField source="speciesA" dest="default"/>
+  <copyField source="speciesB" dest="default"/>
+  <copyField source="taxIdA" dest="default"/>
+  <copyField source="taxIdA_styled" dest="taxId_A_B_styled"/>
+  <copyField source="taxIdB" dest="default"/>
+  <copyField source="taxIdB_styled" dest="taxId_A_B_styled"/>
+  <copyField source="type" dest="default"/>
+  <copyField source="typeA" dest="default"/>
+  <copyField source="typeB" dest="default"/>
+  <copyField source="type_MI_A" dest="default"/>
+  <copyField source="type_MI_A_styled" dest="type_MI_A_B_styled"/>
+  <copyField source="type_MI_B" dest="default"/>
+  <copyField source="type_MI_B_styled" dest="type_MI_A_B_styled"/>
+  <copyField source="type_mi_identifier" dest="default"/>
+  <copyField source="uniqueIdA" dest="default"/>
+  <copyField source="uniqueIdB" dest="default"/>
+  <copyField source="xrefs" dest="default"/>
+  <copyField source="xrefsA" dest="default"/>
+  <copyField source="xrefsB" dest="default"/>
   <copyField source="ac" dest="interaction_identifiers" maxChars="256"/>
   <copyField source="acA" dest="interactor_identifiers" maxChars="256"/>
   <copyField source="acB" dest="interactor_identifiers" maxChars="256"/>
@@ -756,14 +832,12 @@
   <copyField source="xrefs" dest="interaction_identifiers" maxChars="256"/>
   <copyField source="xrefsA" dest="interactor_identifiers" maxChars="256"/>
   <copyField source="xrefsB" dest="interactor_identifiers" maxChars="256"/>
-  <!--  Do we need typeA_s and typeB_s? -->
   <copyField source="typeA" dest="typeA_s" maxChars="256"/>
   <copyField source="typeB" dest="typeB_s" maxChars="256"/>
   <copyField source="typeA" dest="typeA_B_str"/>
   <copyField source="typeB" dest="typeA_B_str"/>
   <copyField source="type_MI_A" dest="type_MI_A_B_str"/>
   <copyField source="type_MI_B" dest="type_MI_A_B_str"/>
-  <!--  Do we need speciesA_s and speciesB_s? -->
   <copyField source="speciesA" dest="speciesA_s" maxChars="256"/>
   <copyField source="speciesB" dest="speciesB_s" maxChars="256"/>
   <copyField source="speciesA" dest="speciesA_B_str"/>
@@ -772,6 +846,10 @@
   <copyField source="taxIdB" dest="taxIdA_B_ls"/>
   <copyField source="identification_method_A" dest="identification_method_A_str" maxChars="256"/>
   <copyField source="identification_method_B" dest="identification_method_B_str" maxChars="256"/>
+  <copyField source="identification_method_A" dest="identification_method_A_B_str"/>
+  <copyField source="identification_method_B" dest="identification_method_A_B_str"/>
+  <copyField source="identification_method_mi_identifier_A" dest="identification_method_mi_identifier_A_B_str"/>
+  <copyField source="identification_method_mi_identifier_B" dest="identification_method_mi_identifier_A_B_str"/>
   <copyField source="biological_role_A" dest="biological_role_A_s" maxChars="256"/>
   <copyField source="biological_role_B" dest="biological_role_B_s" maxChars="256"/>
   <copyField source="experimental_role_A" dest="experimental_role_A_s" maxChars="256"/>
@@ -779,96 +857,28 @@
   <copyField source="expansion_method" dest="expansion_method_s" maxChars="256"/>
   <copyField source="host_organism" dest="host_organism_s" maxChars="256"/>
   <copyField source="publication_authors" dest="publication_authors_str" maxChars="256"/>
-  <!-- Check if you need to remove fields from default, like identifiers -->
   <copyField source="source_database" dest="source_database_s" maxChars="256"/>
   <copyField source="ac" dest="ac_s" maxChars="256"/>
   <copyField source="type" dest="type_s" maxChars="256"/>
+  <copyField source="type_mi_identifier" dest="type_mi_identifier_s" maxChars="256"/>
   <copyField source="detection_method" dest="detection_method_s" maxChars="256"/>
+  <copyField source="detection_method_mi_identifier" dest="detection_method_mi_identifier_s" maxChars="256"/>
   <copyField source="idA" dest="idA_s" maxChars="256"/>
   <copyField source="idB" dest="idB_s" maxChars="256"/>
   <copyField source="acA" dest="acA_s" maxChars="256"/>
   <copyField source="acB" dest="acB_s" maxChars="256"/>
-
-  <!-- styling fields -->
-  <copyField source="taxIdA_styled" dest="taxId_A_B_styled"/>
-  <copyField source="taxIdB_styled" dest="taxId_A_B_styled"/>
-  <copyField source="type_MI_A_styled" dest="type_MI_A_B_styled"/>
-  <copyField source="type_MI_B_styled" dest="type_MI_A_B_styled"/>
-
-  <!--copy selected fields into default-->
-  <copyField source="moleculeA" dest="default"/>
-  <copyField source="moleculeB" dest="default"/>
-  <copyField source="intactNameA" dest="default"/>
-  <copyField source="intactNameB" dest="default"/>
-  <copyField source="altIdsA" dest="default" />
-  <copyField source="altIdsB" dest="default" />
-  <copyField source="idA" dest="default" />
-  <copyField source="idB" dest="default" />
-  <copyField source="identifiers" dest="default" />
-  <copyField source="publication_identifiers" dest="default" />
-  <copyField source="uniqueIdA" dest="default" />
-  <copyField source="uniqueIdB" dest="default" />
-  <copyField source="xrefs" dest="default" />
-  <copyField source="xrefsA" dest="default" />
-  <copyField source="xrefsB" dest="default" />
-  <copyField source="aliasesA" dest="default"/>
-  <copyField source="aliasesB" dest="default"/>
-  <copyField source="detection_method" dest="default"/>
-  <copyField source="detection_method_mi_identifier" dest="default"/>
-  <copyField source="identification_method_A" dest="default" />
-  <copyField source="identification_method_B" dest="default" />
-  <copyField source="identification_method_mi_identifier_A" dest="default" />
-  <copyField source="identification_method_mi_identifier_B" dest="default" />
-  <copyField source="type" dest="default"/>
-  <copyField source="type_mi_identifier" dest="default"/>
-  <copyField source="publication_authors" dest="default" />
-  <copyField source="first_author" dest="default"/>
-  <copyField source="feature_shortlabel_A" dest="default" />
-  <copyField source="feature_shortlabel_B" dest="default" />
-  <copyField source="feature_type_A" dest="default" />
-  <copyField source="feature_type_B" dest="default" />
-  <copyField source="descriptionA" dest="default" />
-  <copyField source="descriptionB" dest="default" />
-
-  <!-- To be decided to be kept or not -->
-
-    <copyField source="speciesA" dest="default"/>
-    <copyField source="speciesB" dest="default"/>
-    <copyField source="taxIdA" dest="default"/>
-    <copyField source="taxIdB" dest="default"/>
-    <copyField source="parameter_types" dest="default" />
-    <copyField source="host_organism" dest="default"/>
-    <copyField source="host_organism_taxId" dest="default"/>
-    <copyField source="typeA" dest="default"/>
-    <copyField source="typeB" dest="default"/>
-    <copyField source="type_MI_A" dest="default"/>
-    <copyField source="type_MI_B" dest="default"/>
-    <!--feature range need to be added in index and then here, just have featureA and featureB and remove feature shortlabel and feature type from above default -->
-    <copyField source="feature_ranges_A" dest="default"/>
-    <copyField source="feature_ranges_B" dest="default"/>
-    <copyField source="publication_annotations" dest="default"/>
-
-    <!-- Advanced Search copy fields -->
-    <copyField source="as_altidA" dest="as_id"/>
-    <copyField source="as_altidB" dest="as_id"/>
-    <copyField source="as_aliasA" dest="as_alias"/>
-    <copyField source="as_aliasB" dest="as_alias"/>
-    <copyField source="as_altidA" dest="as_identifier"/>
-    <copyField source="as_altidB" dest="as_identifier"/>
-    <copyField source="as_aliasA" dest="as_identifier"/>
-    <copyField source="as_aliasB" dest="as_identifier"/>
-    <copyField source="as_taxidA" dest="as_species"/>
-    <copyField source="as_taxidB" dest="as_species"/>
-    <copyField source="as_pbioroleA" dest="as_pbiorole"/>
-    <copyField source="as_pbioroleB" dest="as_pbiorole"/>
-    <copyField source="as_ptypeA" dest="as_ptype"/>
-    <copyField source="as_ptypeB" dest="as_ptype"/>
-    <copyField source="as_ftypeA" dest="as_ftype"/>
-    <copyField source="as_ftypeB" dest="as_ftype"/>
-    <copyField source="as_pmethodA" dest="as_pmethod"/>
-    <copyField source="as_pmethodB" dest="as_pmethod"/>
-    <copyField source="as_pxrefA" dest="as_pxref"/>
-    <copyField source="as_pxrefB" dest="as_pxref"/>
-    <copyField source="as_geneNameA" dest="as_geneName"/>
-    <copyField source="as_geneNameB" dest="as_geneName"/>
+  <copyField source="serialised_interaction" dest="serialised_interaction_str" maxChars="256"/>
+  <copyField source="serialised_xml" dest="serialised_xml_str" maxChars="256"/>
+  <copyField source="xml25Format" dest="xml25Format_str" maxChars="256"/>
+  <copyField source="jsonFormat" dest="jsonFormat_str" maxChars="256"/>
+  <copyField source="tab26Format" dest="tab26Format_str" maxChars="256"/>
+  <copyField source="xml30Format" dest="xml30Format_str" maxChars="256"/>
+  <copyField source="tab27Format" dest="tab27Format_str" maxChars="256"/>
+  <copyField source="tab25Format" dest="tab25Format_str" maxChars="256"/>
+  <copyField source="tab_26_format" dest="tab_26_format_str" maxChars="256"/>
+  <copyField source="json_format" dest="json_format_str" maxChars="256"/>
+  <copyField source="xml_30_format" dest="xml_30_format_str" maxChars="256"/>
+  <copyField source="xml_25_format" dest="xml_25_format_str" maxChars="256"/>
+  <copyField source="tab_27_format" dest="tab_27_format_str" maxChars="256"/>
+  <copyField source="tab_25_format" dest="tab_25_format_str" maxChars="256"/>
 </schema>

--- a/intact-search-interactions-ws/pom.xml
+++ b/intact-search-interactions-ws/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.search.interactions</groupId>
         <artifactId>intact-search-interactions-module</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-search-interactions-ws</artifactId>

--- a/intact-search-interactions-ws/src/main/java/uk/ac/ebi/intact/search/interactions/ws/controller/InteractionSearchController.java
+++ b/intact-search-interactions-ws/src/main/java/uk/ac/ebi/intact/search/interactions/ws/controller/InteractionSearchController.java
@@ -75,6 +75,7 @@ public class InteractionSearchController {
             @RequestParam(value = "interactorSpeciesFilter", required = false) Set<String> interactorSpeciesFilter,
             @RequestParam(value = "interactorTypesFilter", required = false) Set<String> interactorTypesFilter,
             @RequestParam(value = "interactionDetectionMethodsFilter", required = false) Set<String> interactionDetectionMethodsFilter,
+            @RequestParam(value = "participantDetectionMethodsFilter", required = false) Set<String> participantDetectionMethodsFilter,
             @RequestParam(value = "interactionTypesFilter", required = false) Set<String> interactionTypesFilter,
             @RequestParam(value = "interactionHostOrganismsFilter", required = false) Set<String> interactionHostOrganismsFilter,
             @RequestParam(value = "negativeFilter", required = false, defaultValue = "POSITIVE_ONLY") NegativeFilterStatus negativeFilter,
@@ -94,6 +95,7 @@ public class InteractionSearchController {
                         .interactorSpeciesFilter(interactorSpeciesFilter)
                         .interactorTypesFilter(interactorTypesFilter)
                         .interactionDetectionMethodsFilter(interactionDetectionMethodsFilter)
+                        .participantDetectionMethodsFilter(participantDetectionMethodsFilter)
                         .interactionTypesFilter(interactionTypesFilter)
                         .interactionHostOrganismsFilter(interactionHostOrganismsFilter)
                         .negativeFilter(negativeFilter)
@@ -130,6 +132,7 @@ public class InteractionSearchController {
             @RequestParam(value = "interactorSpeciesFilter", required = false) Set<String> interactorSpeciesFilter,
             @RequestParam(value = "interactorTypesFilter", required = false) Set<String> interactorTypesFilter,
             @RequestParam(value = "interactionDetectionMethodsFilter", required = false) Set<String> interactionDetectionMethodsFilter,
+            @RequestParam(value = "participantDetectionMethodsFilter", required = false) Set<String> participantDetectionMethodsFilter,
             @RequestParam(value = "interactionTypesFilter", required = false) Set<String> interactionTypesFilter,
             @RequestParam(value = "interactionHostOrganismsFilter", required = false) Set<String> interactionHostOrganismsFilter,
             @RequestParam(value = "negativeFilter", required = false, defaultValue = "POSITIVE_ONLY") NegativeFilterStatus negativeFilter,
@@ -151,6 +154,7 @@ public class InteractionSearchController {
                         .interactorSpeciesFilter(interactorSpeciesFilter)
                         .interactorTypesFilter(interactorTypesFilter)
                         .interactionDetectionMethodsFilter(interactionDetectionMethodsFilter)
+                        .participantDetectionMethodsFilter(participantDetectionMethodsFilter)
                         .interactionTypesFilter(interactionTypesFilter)
                         .interactionHostOrganismsFilter(interactionHostOrganismsFilter)
                         .negativeFilter(negativeFilter)
@@ -206,6 +210,7 @@ public class InteractionSearchController {
             @RequestParam(value = "interactorSpeciesFilter", required = false) Set<String> interactorSpeciesFilter,
             @RequestParam(value = "interactorTypesFilter", required = false) Set<String> interactorTypesFilter,
             @RequestParam(value = "interactionDetectionMethodsFilter", required = false) Set<String> interactionDetectionMethodsFilter,
+            @RequestParam(value = "participantDetectionMethodsFilter", required = false) Set<String> participantDetectionMethodsFilter,
             @RequestParam(value = "interactionTypesFilter", required = false) Set<String> interactionTypesFilter,
             @RequestParam(value = "interactionHostOrganismsFilter", required = false) Set<String> interactionHostOrganismsFilter,
             @RequestParam(value = "negativeFilter", required = false, defaultValue = "POSITIVE_ONLY") NegativeFilterStatus negativeFilter,
@@ -226,6 +231,7 @@ public class InteractionSearchController {
                 .interactorSpeciesFilter(interactorSpeciesFilter)
                 .interactorTypesFilter(interactorTypesFilter)
                 .interactionDetectionMethodsFilter(interactionDetectionMethodsFilter)
+                .participantDetectionMethodsFilter(participantDetectionMethodsFilter)
                 .interactionTypesFilter(interactionTypesFilter)
                 .interactionHostOrganismsFilter(interactionHostOrganismsFilter)
                 .negativeFilter(negativeFilter)
@@ -288,6 +294,7 @@ public class InteractionSearchController {
             @RequestParam(value = "interactorSpeciesFilter", required = false) Set<String> interactorSpeciesFilter,
             @RequestParam(value = "interactorTypesFilter", required = false) Set<String> interactorTypesFilter,
             @RequestParam(value = "interactionDetectionMethodsFilter", required = false) Set<String> interactionDetectionMethodsFilter,
+            @RequestParam(value = "participantDetectionMethodsFilter", required = false) Set<String> participantDetectionMethodsFilter,
             @RequestParam(value = "interactionTypesFilter", required = false) Set<String> interactionTypesFilter,
             @RequestParam(value = "interactionHostOrganismsFilter", required = false) Set<String> interactionHostOrganismsFilter,
             @RequestParam(value = "negativeFilter", required = false, defaultValue = "POSITIVE_ONLY") NegativeFilterStatus negativeFilter,
@@ -310,6 +317,7 @@ public class InteractionSearchController {
                 .interactorSpeciesFilter(interactorSpeciesFilter)
                 .interactorTypesFilter(interactorTypesFilter)
                 .interactionDetectionMethodsFilter(interactionDetectionMethodsFilter)
+                .participantDetectionMethodsFilter(participantDetectionMethodsFilter)
                 .interactionTypesFilter(interactionTypesFilter)
                 .interactionHostOrganismsFilter(interactionHostOrganismsFilter)
                 .negativeFilter(negativeFilter)
@@ -380,6 +388,7 @@ public class InteractionSearchController {
             @RequestParam(value = "interactorSpeciesFilter", required = false) Set<String> interactorSpeciesFilter,
             @RequestParam(value = "interactorTypesFilter", required = false) Set<String> interactorTypesFilter,
             @RequestParam(value = "interactionDetectionMethodsFilter", required = false) Set<String> interactionDetectionMethodsFilter,
+            @RequestParam(value = "participantDetectionMethodsFilter", required = false) Set<String> participantDetectionMethodsFilter,
             @RequestParam(value = "interactionTypesFilter", required = false) Set<String> interactionTypesFilter,
             @RequestParam(value = "interactionHostOrganismsFilter", required = false) Set<String> interactionHostOrganismsFilter,
             @RequestParam(value = "negativeFilter", required = false, defaultValue = "POSITIVE_ONLY") NegativeFilterStatus negativeFilter,
@@ -395,6 +404,7 @@ public class InteractionSearchController {
                 .interactorSpeciesFilter(interactorSpeciesFilter)
                 .interactorTypesFilter(interactorTypesFilter)
                 .interactionDetectionMethodsFilter(interactionDetectionMethodsFilter)
+                .participantDetectionMethodsFilter(participantDetectionMethodsFilter)
                 .interactionTypesFilter(interactionTypesFilter)
                 .interactionHostOrganismsFilter(interactionHostOrganismsFilter)
                 .negativeFilter(negativeFilter)

--- a/intact-search-interactions-ws/src/main/java/uk/ac/ebi/intact/search/interactions/ws/controller/model/FacetCount.java
+++ b/intact-search-interactions-ws/src/main/java/uk/ac/ebi/intact/search/interactions/ws/controller/model/FacetCount.java
@@ -19,10 +19,12 @@ public class FacetCount<T> {
     public void setValue(String value) {
         if (value != null) {
             String[] styledValue = value.split("__");
-            if (styledValue.length == 3) {
+            if (styledValue.length >= 2) {
                 setTermId(styledValue[0]);
                 this.value = styledValue[1];
-                setVisualProperty(styledValue[2]);
+                if (styledValue.length >= 3) {
+                    setVisualProperty(styledValue[2]);
+                }
             }
             else {
                 this.value = value;

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>uk.ac.ebi.intact.search.interactions</groupId>
     <artifactId>intact-search-interactions-module</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>IntAct Portal :: Search Interactions Parent Module</name>


### PR DESCRIPTION
New SOLR fields for
- interaction detection method MI id
- participant detection method MI ids

Indexing has been tested and new fields are in SOLR.

Update endpoints with filters and facets to use MI ids for interaction type and detection methods.

Update on interaction type and interaction detection method filters and facets allows us to export these filters from IntAct Portal to the Cytoscape app.
New filter for participant detection method allows us to add new filter in IntAct Portal (participant detection method) that already exists in the Cytoscape app.